### PR TITLE
Fix race condition in KV store unit test

### DIFF
--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 package store
 
 // TODO - Fix race conditions via shared mock controller
@@ -26,25 +24,21 @@ var errMock = errors.New("client error")
 func TestDeleteCredentialsObject(t *testing.T) {
 	t.Parallel()
 
-	mockCtrl := gomock.NewController(t)
-	kvClient := mock.NewMockKeyVaultClient(mockCtrl)
-	kvStore := NewMsiKeyVaultStore(kvClient)
-
 	testCases := []struct {
 		name          string
-		goMockCall    func()
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
 		expectedError error
 	}{
 		{
 			name: "Returns success when kv client successfully deletes the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().DeleteSecret(gomock.Any(), mockSecretName, gomock.Any()).Return(azsecrets.DeleteSecretResponse{}, nil)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Returns kv client error when kv client fails to delete the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().DeleteSecret(gomock.Any(), mockSecretName, gomock.Any()).Return(azsecrets.DeleteSecretResponse{}, errMock)
 			},
 			expectedError: errMock,
@@ -55,7 +49,13 @@ func TestDeleteCredentialsObject(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.goMockCall()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
 			if err := kvStore.DeleteCredentialsObject(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}
@@ -65,10 +65,6 @@ func TestDeleteCredentialsObject(t *testing.T) {
 
 func TestGetCredentialsObject(t *testing.T) {
 	t.Parallel()
-
-	mockCtrl := gomock.NewController(t)
-	kvClient := mock.NewMockKeyVaultClient(mockCtrl)
-	kvStore := NewMsiKeyVaultStore(kvClient)
 
 	bogusValue := "bogus"
 	testCredentialsObject := dataplane.CredentialsObject{
@@ -89,19 +85,19 @@ func TestGetCredentialsObject(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		goMockCall    func()
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
 		expectedError error
 	}{
 		{
 			name: "Returns success when kv client successfully gets the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().GetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testGetSecretResponse, nil)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Returns kv client error when kv client fails to get the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().GetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.GetSecretResponse{}, errMock)
 			},
 			expectedError: errMock,
@@ -111,7 +107,13 @@ func TestGetCredentialsObject(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.goMockCall()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
 			response, err := kvStore.GetCredentialsObject(context.Background(), mockSecretName)
 			if !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
@@ -128,18 +130,14 @@ func TestGetCredentialsObject(t *testing.T) {
 func TestNewListSecretsPager(t *testing.T) {
 	t.Parallel()
 
-	mockCtrl := gomock.NewController(t)
-	kvClient := mock.NewMockKeyVaultClient(mockCtrl)
-	kvStore := NewMsiKeyVaultStore(kvClient)
-
 	testCases := []struct {
 		name          string
 		expectedPager *runtime.Pager[azsecrets.ListSecretPropertiesResponse]
-		goMockCall    func()
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
 	}{
 		{
 			name: "Returns a pager",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().NewListSecretPropertiesPager(gomock.Any()).Return(&runtime.Pager[azsecrets.ListSecretPropertiesResponse]{})
 			},
 		},
@@ -148,7 +146,13 @@ func TestNewListSecretsPager(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.goMockCall()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
 			if pager := kvStore.GetCredentialsObjectPager(); pager == nil {
 				t.Error("Expected pager but got nil")
 			}
@@ -159,25 +163,21 @@ func TestNewListSecretsPager(t *testing.T) {
 func TestPurgeDeletedSecret(t *testing.T) {
 	t.Parallel()
 
-	mockCtrl := gomock.NewController(t)
-	kvClient := mock.NewMockKeyVaultClient(mockCtrl)
-	kvStore := NewMsiKeyVaultStore(kvClient)
-
 	testCases := []struct {
 		name          string
-		goMockCall    func()
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
 		expectedError error
 	}{
 		{
 			name: "Returns success when kv client successfully purges the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().PurgeDeletedSecret(gomock.Any(), mockSecretName, gomock.Any()).Return(azsecrets.PurgeDeletedSecretResponse{}, nil)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Returns kv client error when kv client fails to purge the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().PurgeDeletedSecret(gomock.Any(), mockSecretName, gomock.Any()).Return(azsecrets.PurgeDeletedSecretResponse{}, errMock)
 			},
 			expectedError: errMock,
@@ -187,7 +187,13 @@ func TestPurgeDeletedSecret(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.goMockCall()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
 			if err := kvStore.PurgeDeletedCredentialsObject(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}
@@ -198,25 +204,21 @@ func TestPurgeDeletedSecret(t *testing.T) {
 func TestSetCredentialsObject(t *testing.T) {
 	t.Parallel()
 
-	mockCtrl := gomock.NewController(t)
-	kvClient := mock.NewMockKeyVaultClient(mockCtrl)
-	kvStore := NewMsiKeyVaultStore(kvClient)
-
 	testCases := []struct {
 		name          string
-		goMockCall    func()
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
 		expectedError error
 	}{
 		{
 			name: "Returns success when kv client successfully sets the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.SetSecretResponse{}, nil)
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Returns kv client error when kv client fails to set the secret",
-			goMockCall: func() {
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
 				kvClient.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.SetSecretResponse{}, errMock)
 			},
 			expectedError: errMock,
@@ -226,7 +228,13 @@ func TestSetCredentialsObject(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			tc.goMockCall()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
 			if err := kvStore.SetCredentialsObject(context.Background(), mockSecretName, dataplane.CredentialsObject{}); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1,7 +1,6 @@
-package store
+//go:build unit
 
-// TODO - Fix race conditions via shared mock controller
-// See client_test.go in dataplane package for an example of how to fix this
+package store
 
 import (
 	"context"


### PR DESCRIPTION
Previously, we shared mocks between test cases. Refactor the code to use local instances of the mock.

Since we use parallel tests, test execution time affected when the mock expected certain calls, so this would cause tests to unnecessarily fail.