### PR TITLE
Support requesting multiple UA MSIs

### DIFF
--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -20,7 +20,7 @@ const (
 	// TODO - Tie the module version to update automatically with new releases
 	moduleVersion = "v0.0.1"
 
-	resourceIDsTag = "resource_ids"
+	resourceIDTag = "resource_id"
 )
 
 type ManagedIdentityClient struct {
@@ -29,7 +29,7 @@ type ManagedIdentityClient struct {
 
 type UserAssignedMSIRequest struct {
 	IdentityURL string   `validate:"required,http_url"`
-	ResourceIDs []string `validate:"required,resource_ids"`
+	ResourceIDs []string `validate:"required,resource_id"`
 	TenantID    string   `validate:"required,uuid"`
 }
 
@@ -72,7 +72,7 @@ func NewClient(aud, cloud string, cred azcore.TokenCredential) (*ManagedIdentity
 
 func (c *ManagedIdentityClient) GetUserAssignedMSI(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
-	validate.RegisterValidation(resourceIDsTag, validateResourceIDs)
+	validate.RegisterValidation(resourceIDTag, validateResourceIDTag)
 	if err := validate.Struct(request); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidRequest, err)
 	}
@@ -106,7 +106,7 @@ func (c *ManagedIdentityClient) GetUserAssignedMSI(ctx context.Context, request 
 	return &CredentialsObject{CredentialsObject: creds.CredentialsObject}, nil
 }
 
-func validateResourceIDs(fl validator.FieldLevel) bool {
+func validateResourceIDTag(fl validator.FieldLevel) bool {
 	field := fl.Field()
 
 	// Confirm we have a slice of strings

--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -92,7 +92,7 @@ func (c *ManagedIdentityClient) GetUserAssignedMSI(ctx context.Context, request 
 		return nil, fmt.Errorf("%w: %w", errGetCreds, err)
 	}
 
-	if err := validateUserAssignedMSIs(creds.ExplicitIdentities, request.ResourceIDs); err != nil {
+	if err := validateUserAssignedMSI(creds.ExplicitIdentities, request.ResourceIDs); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +151,7 @@ func isUserAssignedMSIResource(resourceID string) bool {
 	return resourceType.Namespace == expectedNamespace && resourceType.Type == expectedResourceType
 }
 
-func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, resourceIDs []string) error {
+func validateUserAssignedMSI(identities []*swagger.NestedCredentialsObject, resourceIDs []string) error {
 	if len(identities) != len(resourceIDs) {
 		return fmt.Errorf("%w, found %d identities instead", errNumberOfMSIs, len(identities))
 	}

--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -92,10 +92,6 @@ func (c *ManagedIdentityClient) GetUserAssignedMSI(ctx context.Context, request 
 		return nil, fmt.Errorf("%w: %w", errGetCreds, err)
 	}
 
-	if len(creds.ExplicitIdentities) != len(request.ResourceIDs) {
-		return nil, fmt.Errorf("%w, found %d identities instead", errNumberOfMSIs, len(creds.ExplicitIdentities))
-	}
-
 	if err := validateUserAssignedMSIs(creds.ExplicitIdentities, request.ResourceIDs); err != nil {
 		return nil, err
 	}
@@ -156,6 +152,10 @@ func isUserAssignedMSIResource(resourceID string) bool {
 }
 
 func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, resourceIDs []string) error {
+	if len(identities) != len(resourceIDs) {
+		return fmt.Errorf("%w, found %d identities instead", errNumberOfMSIs, len(identities))
+	}
+
 	resourceIDMap := make(map[string]interface{})
 	for _, identity := range identities {
 		if identity == nil {

--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -70,7 +70,7 @@ func NewClient(aud, cloud string, cred azcore.TokenCredential) (*ManagedIdentity
 	return &ManagedIdentityClient{swaggerClient: swaggerClient}, nil
 }
 
-func (c *ManagedIdentityClient) GetUserAssignedMSI(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
+func (c *ManagedIdentityClient) GetUserAssignedIdentities(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	validate.RegisterValidation(resourceIDsTag, validateResourceIDs)
 	if err := validate.Struct(request); err != nil {

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -166,7 +166,7 @@ func TestGetUserAssignedMSI(t *testing.T) {
 	}
 }
 
-func TestValidateUserAssignedMSIs(t *testing.T) {
+func TestValidateUserAssignedMSI(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -214,7 +214,7 @@ func TestValidateUserAssignedMSIs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			msi := tc.getMSI()
-			if err := validateUserAssignedMSIs(msi, tc.resourceIDs); !errors.Is(err, tc.expectedErr) {
+			if err := validateUserAssignedMSI(msi, tc.resourceIDs); !errors.Is(err, tc.expectedErr) {
 				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
 			}
 		})

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -99,6 +99,18 @@ func TestGetUserAssignedMSI(t *testing.T) {
 			expectedErr: errNumberOfMSIs,
 		},
 		{
+			name: "Mismatched number of MSIs",
+			goMockCall: func(swaggerClient *mock.MockswaggerMSIClient) {
+				uaMSI := getTestMSI("bogus")
+				identities := []*swagger.NestedCredentialsObject{uaMSI}
+				swaggerClient.EXPECT().Getcreds(gomock.Any(), gomock.Any(), gomock.Any()).Return(swagger.ManagedIdentityDataPlaneAPIClientGetcredsResponse{
+					CredentialsObject: swagger.CredentialsObject{ExplicitIdentities: identities},
+				}, nil)
+			},
+			request:     UserAssignedMSIRequest{IdentityURL: validIdentityURL, ResourceIDs: []string{validResourceID, validResourceID}, TenantID: validTenantID},
+			expectedErr: errNumberOfMSIs,
+		},
+		{
 			name: "Valid request - single MSI",
 			goMockCall: func(swaggerClient *mock.MockswaggerMSIClient) {
 				resourceID := validResourceID

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -216,7 +216,7 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			msi := tc.getMSI()
-			if err := validateUserAssignedMSI(msi, tc.resourceIDs); !errors.Is(err, tc.expectedErr) {
+			if err := validateUserAssignedMSIs(msi, tc.resourceIDs); !errors.Is(err, tc.expectedErr) {
 				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
 			}
 		})

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package dataplane
 
 import (

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -99,7 +99,7 @@ func TestGetUserAssignedMSI(t *testing.T) {
 			expectedErr: errNumberOfMSIs,
 		},
 		{
-			name: "Valid request",
+			name: "Valid request - single MSI",
 			goMockCall: func(swaggerClient *mock.MockswaggerMSIClient) {
 				resourceID := validResourceID
 				tenantID := validTenantID
@@ -114,6 +114,24 @@ func TestGetUserAssignedMSI(t *testing.T) {
 				}, nil)
 			},
 			request:     UserAssignedMSIRequest{IdentityURL: validIdentityURL, ResourceIDs: []string{validResourceID}, TenantID: validTenantID},
+			expectedErr: nil,
+		},
+		{
+			name: "Valid request - multiple MSIs",
+			goMockCall: func(swaggerClient *mock.MockswaggerMSIClient) {
+				resourceID := validResourceID
+				tenantID := validTenantID
+
+				uaMSI := getTestMSI("bogus")
+				uaMSI.ResourceID = &resourceID
+				uaMSI.TenantID = &tenantID
+
+				identities := []*swagger.NestedCredentialsObject{uaMSI, uaMSI}
+				swaggerClient.EXPECT().Getcreds(gomock.Any(), gomock.Any(), gomock.Any()).Return(swagger.ManagedIdentityDataPlaneAPIClientGetcredsResponse{
+					CredentialsObject: swagger.CredentialsObject{ExplicitIdentities: identities},
+				}, nil)
+			},
+			request:     UserAssignedMSIRequest{IdentityURL: validIdentityURL, ResourceIDs: []string{validResourceID, validResourceID}, TenantID: validTenantID},
 			expectedErr: nil,
 		},
 	}

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -166,40 +166,45 @@ func TestGetUserAssignedMSI(t *testing.T) {
 	}
 }
 
-/*
 func TestValidateUserAssignedMSIs(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name        string
-		getMSI      func() *swagger.NestedCredentialsObject
-		resourceID  string
+		getMSI      func() []*swagger.NestedCredentialsObject
+		resourceIDs []string
 		expectedErr error
 	}{
 		{
-			name:        "nil identity",
-			getMSI:      func() *swagger.NestedCredentialsObject { return nil },
-			resourceID:  "someResourceID",
-			expectedErr: errNilMSI,
+			name:        "nil credential object slice",
+			getMSI:      func() []*swagger.NestedCredentialsObject { return nil },
+			resourceIDs: []string{"someResourceID"},
+			expectedErr: errNumberOfMSIs,
 		},
 		{
-			name:        "nil fields",
-			getMSI:      func() *swagger.NestedCredentialsObject { return &swagger.NestedCredentialsObject{} },
-			resourceID:  "someResourceID",
+			name: "nil fields",
+			getMSI: func() []*swagger.NestedCredentialsObject {
+				return []*swagger.NestedCredentialsObject{&swagger.NestedCredentialsObject{}}
+			},
+			resourceIDs: []string{"someResourceID"},
 			expectedErr: errNilField,
 		},
 		{
 			name: "mismatched resourceID",
-			getMSI: func() *swagger.NestedCredentialsObject {
-				return getTestMSI("bogus")
+			getMSI: func() []*swagger.NestedCredentialsObject {
+				testMSI := getTestMSI("bogus")
+				return []*swagger.NestedCredentialsObject{testMSI}
 			},
-			resourceID:  "someResourceID",
+			resourceIDs: []string{"someResourceID"},
 			expectedErr: errResourceIDMismatch,
 		},
 		{
-			name:        "success",
-			getMSI:      func() *swagger.NestedCredentialsObject { return getTestMSI(validResourceID) },
-			resourceID:  validResourceID,
+			name: "success",
+			getMSI: func() []*swagger.NestedCredentialsObject {
+				testMSI := getTestMSI(validResourceID)
+				return []*swagger.NestedCredentialsObject{testMSI}
+			},
+			resourceIDs: []string{validResourceID},
 			expectedErr: nil,
 		},
 	}
@@ -209,13 +214,12 @@ func TestValidateUserAssignedMSIs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			msi := tc.getMSI()
-			if err := validateUserAssignedMSIs(msi, tc.resourceID); !errors.Is(err, tc.expectedErr) {
+			if err := validateUserAssignedMSIs(msi, tc.resourceIDs); !errors.Is(err, tc.expectedErr) {
 				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
 			}
 		})
 	}
 }
-*/
 
 func getTestMSI(placeHolder string) *swagger.NestedCredentialsObject {
 	return &swagger.NestedCredentialsObject{

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -39,7 +39,7 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-func TestGetUserAssignedMSI(t *testing.T) {
+func TestGetUserAssignedIdentities(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -161,7 +161,7 @@ func TestGetUserAssignedMSI(t *testing.T) {
 			tc.goMockCall(swaggerClient)
 
 			msiClient := &ManagedIdentityClient{swaggerClient: swaggerClient}
-			if _, err := msiClient.GetUserAssignedMSI(context.Background(), tc.request); !errors.Is(err, tc.expectedErr) {
+			if _, err := msiClient.GetUserAssignedIdentities(context.Background(), tc.request); !errors.Is(err, tc.expectedErr) {
 				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
 			}
 		})

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -37,7 +37,7 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-func TestGetUserAssignedMSIs(t *testing.T) {
+func TestGetUserAssignedMSI(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {


### PR DESCRIPTION
Per a comment from @weinong in #9 PR, we should support generalization for getting user-assigned managed identities. Consequently, clients should be able to make a request for multiple UA MSIs.