### PR TITLE
Enable setting/getting secret enabled, expires and not before

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -53,8 +53,16 @@ func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName 
 	if err := credentialsObject.UnmarshalJSON([]byte(*secret.Value)); err != nil {
 		return nil, err
 	}
-	secretProperties := SecretProperties{Name: secretName}
+
+	secretProperties := SecretProperties{
+		Name:      secretName,
+		Enabled:   true, // Default to true
+		Expires:   time.Time{},
+		NotBefore: time.Time{},
+	}
+
 	if secret.Attributes != nil {
+		// Override defaults if values are present
 		if secret.Attributes.Enabled != nil {
 			secretProperties.Enabled = *secret.Attributes.Enabled
 		}
@@ -64,11 +72,6 @@ func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName 
 		if secret.Attributes.NotBefore != nil {
 			secretProperties.NotBefore = *secret.Attributes.NotBefore
 		}
-	} else {
-		// Set default values
-		secretProperties.Enabled = true
-		secretProperties.Expires = time.Time{}
-		secretProperties.NotBefore = time.Time{}
 	}
 
 	return &SecretResponse{CredentialsObject: credentialsObject, Properties: secretProperties}, nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -10,6 +11,18 @@ import (
 
 type MsiKeyVaultStore struct {
 	kvClient KeyVaultClient
+}
+
+type SecretProperties struct {
+	Enabled   bool
+	Expires   time.Time
+	Name      string
+	NotBefore time.Time
+}
+
+type SecretResponse struct {
+	CredentialsObject dataplane.CredentialsObject
+	Properties        SecretProperties
 }
 
 func NewMsiKeyVaultStore(kvClient KeyVaultClient) *MsiKeyVaultStore {
@@ -28,20 +41,37 @@ func (s *MsiKeyVaultStore) DeleteCredentialsObject(ctx context.Context, secretNa
 
 // Get a credentials object from the key vault using the specified secret name.
 // The latest version of the secret will always be returned.
-func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName string) (dataplane.CredentialsObject, error) {
+func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName string) (*SecretResponse, error) {
 	// https://github.com/Azure/azure-sdk-for-go/blob/3fab729f1bd43098837ddc34931fec6c342fa3ef/sdk/security/keyvault/azsecrets/client.go#L197
 	latestSecretVersion := ""
 	secret, err := s.kvClient.GetSecret(ctx, secretName, latestSecretVersion, nil)
 	if err != nil {
-		return dataplane.CredentialsObject{}, err
+		return nil, err
 	}
 
 	var credentialsObject dataplane.CredentialsObject
 	if err := credentialsObject.UnmarshalJSON([]byte(*secret.Value)); err != nil {
-		return dataplane.CredentialsObject{}, err
+		return nil, err
+	}
+	secretProperties := SecretProperties{Name: secretName}
+	if secret.Attributes != nil {
+		if secret.Attributes.Enabled != nil {
+			secretProperties.Enabled = *secret.Attributes.Enabled
+		}
+		if secret.Attributes.Expires != nil {
+			secretProperties.Expires = *secret.Attributes.Expires
+		}
+		if secret.Attributes.NotBefore != nil {
+			secretProperties.NotBefore = *secret.Attributes.NotBefore
+		}
+	} else {
+		// Set default values
+		secretProperties.Enabled = true
+		secretProperties.Expires = time.Time{}
+		secretProperties.NotBefore = time.Time{}
 	}
 
-	return credentialsObject, nil
+	return &SecretResponse{CredentialsObject: credentialsObject, Properties: secretProperties}, nil
 }
 
 // Get a pager for listing credentials objects from the key vault.
@@ -61,7 +91,7 @@ func (s *MsiKeyVaultStore) PurgeDeletedCredentialsObject(ctx context.Context, se
 
 // Set a credentials object in the key vault using the specified secret name.
 // If the secret already exists, key vault will create a new version of the secret.
-func (s *MsiKeyVaultStore) SetCredentialsObject(ctx context.Context, secretName string, credentialsObject dataplane.CredentialsObject) error {
+func (s *MsiKeyVaultStore) SetCredentialsObject(ctx context.Context, properties SecretProperties, credentialsObject dataplane.CredentialsObject) error {
 	credentialsObjectBuffer, err := credentialsObject.MarshalJSON()
 	if err != nil {
 		return err
@@ -70,8 +100,13 @@ func (s *MsiKeyVaultStore) SetCredentialsObject(ctx context.Context, secretName 
 	credentialsObjectString := string(credentialsObjectBuffer)
 	setSecretParameters := azsecrets.SetSecretParameters{
 		Value: &credentialsObjectString,
+		SecretAttributes: &azsecrets.SecretAttributes{
+			Enabled:   &properties.Enabled,
+			Expires:   &properties.Expires,
+			NotBefore: &properties.NotBefore,
+		},
 	}
-	if _, err := s.kvClient.SetSecret(ctx, secretName, setSecretParameters, nil); err != nil {
+	if _, err := s.kvClient.SetSecret(ctx, properties.Name, setSecretParameters, nil); err != nil {
 		return err
 	}
 

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package integration
 
 import (
@@ -57,7 +55,7 @@ func TestStore(t *testing.T) {
 	}
 	defer r.Stop()
 
-	store, err := createMsiStore(r, cred)
+	msiStore, err := createMsiStore(r, cred)
 	if err != nil {
 		t.Fatalf("Failed to create MSI store: %s", err)
 	}
@@ -70,25 +68,28 @@ func TestStore(t *testing.T) {
 		},
 	}
 
-	if err := store.SetCredentialsObject(context.Background(), bogus, testCredentialsObject); err != nil {
+	props := store.SecretProperties{
+		Name: test.Bogus,
+	}
+	if err := msiStore.SetCredentialsObject(context.Background(), props, testCredentialsObject); err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to set credentials object: %s", err)
 	}
 
 	// Get the credentials object from the store
-	returnedCredentialsObject, err := store.GetCredentialsObject(context.Background(), bogus)
+	resp, err := msiStore.GetCredentialsObject(context.Background(), bogus)
 	if err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to get credentials object: %s", err)
 	}
 
-	if !reflect.DeepEqual(testCredentialsObject, returnedCredentialsObject) {
+	if !reflect.DeepEqual(testCredentialsObject, resp.CredentialsObject) {
 		t.Errorf(`Credential objects do not match. 
-		          Returned has client ID %s, expected %s`, *returnedCredentialsObject.ClientID, *testCredentialsObject.ClientID)
+		          Returned has client ID %s, expected %s`, *resp.CredentialsObject.ClientID, *testCredentialsObject.ClientID)
 	}
 
 	// Delete the credentials object from the store
-	if err := store.DeleteCredentialsObject(context.Background(), bogus); err != nil {
+	if err := msiStore.DeleteCredentialsObject(context.Background(), bogus); err != nil {
 		t.Errorf("Failed to delete credentials object: %s", err)
 	}
 }


### PR DESCRIPTION
This allows consumers to optionally set these key vault secret values, so they don't have to read + unmarshall the credentials object to read these values.