### PR TITLE
Downgrade to Go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/msi-dataplane
 
-go 1.22
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1


### PR DESCRIPTION
Per Go 1.21+ versions, the min version specified in Go mod file is a _requirement_: https://go.dev/doc/modules/gomod-ref#go. This means external Go code consuming this module must use that min version of Go.

Since we want to import this code in ARO-RP ([PR to update to 1.21](https://github.com/Azure/ARO-RP/pull/3698)), we have to downgrade this version.