### PR TITLE
Set x5c header when requesting managed identity tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
 	github.com/go-playground/validator/v10 v10.22.0
 	go.uber.org/mock v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 h1:U2rTu3Ef+7w9FHKIAXM6ZyqF3UOWJZ12zIm8zECAFfg=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 h1:jBQA3cKT4L2rWMpgE7Yt3Hwh2aUj8KXjIGLxjHeYNNo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0/go.mod h1:4OG6tQ9EOP/MT0NMjDlRzWoVFxfu9rN9B2X+tlSVktg=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0 h1:h4Zxgmi9oyZL2l8jeg1iRTqPloHktywWcu0nlJmo1tA=

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -75,7 +75,7 @@ func getClientCertificateCredential(identity swagger.NestedCredentialsObject, cl
 			Cloud: getAzCoreCloud(cloud),
 		},
 
-		// X5c header required: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingrequestingatoken
+		// x5c header required: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingrequestingatoken
 		SendCertificateChain: true,
 	}
 

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -70,13 +70,17 @@ func getClientCertificateCredential(identity swagger.NestedCredentialsObject, cl
 		return nil, fmt.Errorf("%w: %s", errNilField, strings.Join(missing, ","))
 	}
 
-	// Set the regional AAD endpoint
-	// https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingcredentialapiversion2019-08-31
 	opts := &azidentity.ClientCertificateCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
 			Cloud: getAzCoreCloud(cloud),
 		},
+
+		// X5c header required: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingrequestingatoken
+		SendCertificateChain: true,
 	}
+
+	// Set the regional AAD endpoint
+	// https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingcredentialapiversion2019-08-31
 	opts.Cloud.ActiveDirectoryAuthorityHost = *identity.AuthenticationEndpoint
 
 	// Parse the certificate and private key from the base64 encoded secret


### PR DESCRIPTION
- Bump `azidentity` pkg to 1.7.0 to ensure compliance with MSI team's requirements
- Set x5c header, as this is also required.