### PR TITLE
Add constructor for user-assigned identities

### DIFF
--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -107,7 +107,7 @@ func (c *ManagedIdentityClient) GetUserAssignedIdentities(ctx context.Context, r
 	}
 
 	credentialsObject := CredentialsObject{CredentialsObject: creds.CredentialsObject}
-	return &UserAssignedIdentities{CredentialsObject: credentialsObject, cloud: c.cloud}, nil
+	return NewUserAssignedIdentities(credentialsObject, c.cloud)
 }
 
 func validateResourceIDs(fl validator.FieldLevel) bool {

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -18,7 +18,8 @@ var (
 	errDecodeClientSecret = errors.New("failed to decode client secret")
 	errParseCertificate   = errors.New("failed to parse certificate")
 	errNilField           = errors.New("expected non nil field in identity")
-	errResourceIDNotFound = errors.New("resource ID not found in user-assigned managed identity	")
+	errNoUserAssignedMSIs = errors.New("credentials object does not contain user-assigned managed identities")
+	errResourceIDNotFound = errors.New("resource ID not found in user-assigned managed identity")
 )
 
 // CredentialsObject is a wrapper around the swagger.CredentialsObject to add additional functionality
@@ -30,6 +31,14 @@ type CredentialsObject struct {
 type UserAssignedIdentities struct {
 	CredentialsObject
 	cloud string
+}
+
+// Constructor for UserAssignedIdentities object
+func NewUserAssignedIdentities(c CredentialsObject, cloud string) (*UserAssignedIdentities, error) {
+	if !c.IsUserAssigned() {
+		return nil, errNoUserAssignedMSIs
+	}
+	return &UserAssignedIdentities{CredentialsObject: c, cloud: cloud}, nil
 }
 
 // This method may be used by clients to check if they can use the object as a user-assigned managed identity

--- a/pkg/dataplane/identity_test.go
+++ b/pkg/dataplane/identity_test.go
@@ -50,6 +50,48 @@ func TestIsUserAssigned(t *testing.T) {
 		})
 	}
 }
+
+func TestNewUserAssignedIdentities(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		c           CredentialsObject
+		expectedErr error
+	}{
+		{
+			name: "No user-assigned managed identities",
+			c: CredentialsObject{
+				CredentialsObject: swagger.CredentialsObject{
+					ExplicitIdentities: []*swagger.NestedCredentialsObject{},
+				},
+			},
+			expectedErr: errNoUserAssignedMSIs,
+		},
+		{
+			name: "User-assigned managed identities present",
+			c: CredentialsObject{
+				CredentialsObject: swagger.CredentialsObject{
+					ExplicitIdentities: []*swagger.NestedCredentialsObject{
+						test.GetTestMSI(test.Bogus),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewUserAssignedIdentities(tc.c, test.Bogus); !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
+			}
+		})
+	}
+}
+
 func TestGetCredential(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Since the store unmarshalls/marshals `dataplane.CredentialsObject`, we need a way to convert that into one of our identity objects (user-assigned for now, will implement system assigned in the future). 