### PR TITLE
Bug fixes after canary testing

### DIFF
--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -96,6 +96,10 @@ func getClientCertificateCredential(identity swagger.NestedCredentialsObject, cl
 
 		// x5c header required: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardingrequestingatoken
 		SendCertificateChain: true,
+
+		// Disable instance discovery because MSI credential may have regional AAD endpoint that instance discovery endpoint doesn't support
+		// e.g. when MSI credential has westus2.login.microsoft.com, it will cause instance discovery to fail with HTTP 400
+		DisableInstanceDiscovery: true,
 	}
 
 	// Set the regional AAD endpoint

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -125,12 +124,8 @@ func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, res
 		if identity == nil {
 			return errNilMSI
 		}
-
-		v := reflect.ValueOf(*identity)
-		for i := 0; i < v.NumField(); i++ {
-			if v.Field(i).IsNil() {
-				return fmt.Errorf("%w, field %s", errNilField, v.Type().Field(i).Name)
-			}
+		if identity.ResourceID == nil {
+			return fmt.Errorf("%w, resource ID", errNilField)
 		}
 		resourceIDMap[*identity.ResourceID] = true
 	}

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -138,7 +138,11 @@ func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, res
 	}
 
 	for _, resourceID := range resourceIDs {
-		if _, ok := resourceIDMap[resourceID]; !ok {
+		armResourceID, err := arm.ParseResourceID(resourceID)
+		if err != nil {
+			return fmt.Errorf("%w for requested resource ID %s: %w", errInvalidResourceID, resourceID, err)
+		}
+		if _, ok := resourceIDMap[armResourceID.String()]; !ok {
 			return fmt.Errorf("%w, resource ID %s", errResourceIDNotFound, resourceID)
 		}
 	}

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azcloud "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/msi-dataplane/pkg/dataplane/swagger"
@@ -15,6 +16,7 @@ import (
 var (
 	// Errors returned when processing idenities
 	errDecodeClientSecret = errors.New("failed to decode client secret")
+	errInvalidResourceID  = errors.New("invalid resource ID")
 	errParseCertificate   = errors.New("failed to parse certificate")
 	errNilField           = errors.New("expected non nil field in identity")
 	errNoUserAssignedMSIs = errors.New("credentials object does not contain user-assigned managed identities")
@@ -127,6 +129,11 @@ func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, res
 		if identity.ResourceID == nil {
 			return fmt.Errorf("%w, resource ID", errNilField)
 		}
+		_, err := arm.ParseResourceID(*identity.ResourceID)
+		if err != nil {
+			return fmt.Errorf("%w for resource ID %s: %w", errInvalidResourceID, *identity.ResourceID, err)
+		}
+
 		resourceIDMap[*identity.ResourceID] = true
 	}
 

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -129,12 +129,12 @@ func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, res
 		if identity.ResourceID == nil {
 			return fmt.Errorf("%w, resource ID", errNilField)
 		}
-		_, err := arm.ParseResourceID(*identity.ResourceID)
+		armResourceID, err := arm.ParseResourceID(*identity.ResourceID)
 		if err != nil {
-			return fmt.Errorf("%w for resource ID %s: %w", errInvalidResourceID, *identity.ResourceID, err)
+			return fmt.Errorf("%w for received resource ID %s: %w", errInvalidResourceID, *identity.ResourceID, err)
 		}
 
-		resourceIDMap[*identity.ResourceID] = true
+		resourceIDMap[armResourceID.String()] = true
 	}
 
 	for _, resourceID := range resourceIDs {

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -61,6 +61,15 @@ func (u UserAssignedIdentities) GetCredential(resourceID string) (*azidentity.Cl
 	return nil, errResourceIDNotFound
 }
 
+func getAzCoreCloud(cloud string) azcloud.Configuration {
+	switch cloud {
+	case AzureUSGovCloud:
+		return azcloud.AzureGovernment
+	default:
+		return azcloud.AzurePublic
+	}
+}
+
 func getClientCertificateCredential(identity swagger.NestedCredentialsObject, cloud string) (*azidentity.ClientCertificateCredential, error) {
 	// Double check nil pointers so we don't panic
 	fieldsToCheck := map[string]*string{
@@ -133,13 +142,4 @@ func validateUserAssignedMSIs(identities []*swagger.NestedCredentialsObject, res
 	}
 
 	return nil
-}
-
-func getAzCoreCloud(cloud string) azcloud.Configuration {
-	switch cloud {
-	case AzureUSGovCloud:
-		return azcloud.AzureGovernment
-	default:
-		return azcloud.AzurePublic
-	}
 }

--- a/pkg/dataplane/identity_test.go
+++ b/pkg/dataplane/identity_test.go
@@ -302,12 +302,21 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 			expectedErr: errResourceIDNotFound,
 		},
 		{
-			name: "invalid resourceID",
+			name: "invalid response resourceID",
 			getMSI: func() []*swagger.NestedCredentialsObject {
 				testMSI := test.GetTestMSI(test.Bogus)
 				return []*swagger.NestedCredentialsObject{testMSI}
 			},
 			resourceIDs: []string{test.ValidResourceID},
+			expectedErr: errInvalidResourceID,
+		},
+		{
+			name: "invalid requested resourceID",
+			getMSI: func() []*swagger.NestedCredentialsObject {
+				testMSI := test.GetTestMSI(test.ValidResourceID)
+				return []*swagger.NestedCredentialsObject{testMSI}
+			},
+			resourceIDs: []string{test.Bogus},
 			expectedErr: errInvalidResourceID,
 		},
 		{

--- a/pkg/dataplane/identity_test.go
+++ b/pkg/dataplane/identity_test.go
@@ -118,7 +118,7 @@ func TestGetCredential(t *testing.T) {
 				},
 			},
 			resourceID:  "",
-			expectedErr: errResourceIDNotFound,
+			expectedErr: errParseResourceID,
 		},
 		{
 			name:         "no identities present",
@@ -127,7 +127,35 @@ func TestGetCredential(t *testing.T) {
 			expectedErr:  errResourceIDNotFound,
 		},
 		{
-			name: "Invalid client secret",
+			name: "invalid requested resourceID",
+			uaIdentities: UserAssignedIdentities{
+				CredentialsObject: CredentialsObject{
+					CredentialsObject: swagger.CredentialsObject{
+						ExplicitIdentities: []*swagger.NestedCredentialsObject{
+							test.GetTestMSI(test.ValidResourceID),
+						},
+					},
+				},
+			},
+			resourceID:  test.Bogus,
+			expectedErr: errParseResourceID,
+		},
+		{
+			name: "invalid identity resourceID",
+			uaIdentities: UserAssignedIdentities{
+				CredentialsObject: CredentialsObject{
+					CredentialsObject: swagger.CredentialsObject{
+						ExplicitIdentities: []*swagger.NestedCredentialsObject{
+							test.GetTestMSI(test.Bogus),
+						},
+					},
+				},
+			},
+			resourceID:  test.ValidResourceID,
+			expectedErr: errParseResourceID,
+		},
+		{
+			name: "invalid client secret",
 			uaIdentities: UserAssignedIdentities{
 				CredentialsObject: CredentialsObject{
 					CredentialsObject: swagger.CredentialsObject{
@@ -308,7 +336,7 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 				return []*swagger.NestedCredentialsObject{testMSI}
 			},
 			resourceIDs: []string{test.ValidResourceID},
-			expectedErr: errInvalidResourceID,
+			expectedErr: errParseResourceID,
 		},
 		{
 			name: "invalid requested resourceID",
@@ -317,7 +345,7 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 				return []*swagger.NestedCredentialsObject{testMSI}
 			},
 			resourceIDs: []string{test.Bogus},
-			expectedErr: errInvalidResourceID,
+			expectedErr: errParseResourceID,
 		},
 		{
 			name: "success",

--- a/pkg/dataplane/identity_test.go
+++ b/pkg/dataplane/identity_test.go
@@ -302,6 +302,15 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 			expectedErr: errResourceIDNotFound,
 		},
 		{
+			name: "invalid resourceID",
+			getMSI: func() []*swagger.NestedCredentialsObject {
+				testMSI := test.GetTestMSI(test.Bogus)
+				return []*swagger.NestedCredentialsObject{testMSI}
+			},
+			resourceIDs: []string{test.ValidResourceID},
+			expectedErr: errInvalidResourceID,
+		},
+		{
 			name: "success",
 			getMSI: func() []*swagger.NestedCredentialsObject {
 				testMSI := test.GetTestMSI(test.ValidResourceID)

--- a/pkg/dataplane/identity_test.go
+++ b/pkg/dataplane/identity_test.go
@@ -294,9 +294,11 @@ func TestValidateUserAssignedMSI(t *testing.T) {
 			name: "mismatched resourceID",
 			getMSI: func() []*swagger.NestedCredentialsObject {
 				testMSI := test.GetTestMSI(test.Bogus)
+				resourceID := test.ValidResourceID + "-bogus"
+				testMSI.ResourceID = test.StringPtr(resourceID)
 				return []*swagger.NestedCredentialsObject{testMSI}
 			},
-			resourceIDs: []string{"someResourceID"},
+			resourceIDs: []string{test.ValidResourceID},
 			expectedErr: errResourceIDNotFound,
 		},
 		{


### PR DESCRIPTION
Based off of test branch: https://github.com/Azure/msi-dataplane/pull/26

- Use `arm.ParseResourceID()` to validate resource IDs and compare. Prevents errors like different casing.
- During UAMSI validation, don't check if every field is nil. Some fields (ex: custom claims) may be nil on a valid UAMSI.
- Disable instance discovery when obtaining MSI credential.