### PR TITLE
Add new interfaces to support operations on nested credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
 	github.com/go-playground/validator/v10 v10.22.0
+	github.com/google/go-cmp v0.6.0
 	go.uber.org/mock v0.4.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0
 )
@@ -18,7 +19,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -85,7 +85,7 @@ func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName 
 	}
 
 	var credentialsObject dataplane.CredentialsObject
-	if err := credentialsObject.UnmarshalJSON([]byte(secretObject.value)); err != nil {
+	if err := credentialsObject.Values.UnmarshalJSON([]byte(secretObject.value)); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +151,7 @@ func (s *MsiKeyVaultStore) GetDeletedCredentialsObject(ctx context.Context, secr
 	}
 
 	var credentialsObject dataplane.CredentialsObject
-	if err := credentialsObject.UnmarshalJSON([]byte(deletedSecretObject.value)); err != nil {
+	if err := credentialsObject.Values.UnmarshalJSON([]byte(deletedSecretObject.value)); err != nil {
 		return nil, err
 	}
 
@@ -226,7 +226,7 @@ func (s *MsiKeyVaultStore) PurgeDeletedSecretObject(ctx context.Context, secretN
 
 // Set a credentials object in the key vault using the specified secret name.
 func (s *MsiKeyVaultStore) SetCredentialsObject(ctx context.Context, properties SecretProperties, credentialsObject dataplane.CredentialsObject) error {
-	credentialsObjectBuffer, err := credentialsObject.MarshalJSON()
+	credentialsObjectBuffer, err := credentialsObject.Values.MarshalJSON()
 	if err != nil {
 		return err
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
+	"github.com/Azure/msi-dataplane/pkg/dataplane/swagger"
 )
 
 var (
@@ -20,9 +21,14 @@ type DeletedSecretProperties struct {
 	DeletedDate   time.Time
 }
 
-type DeletedSecretResponse struct {
+type DeletedCredentialsObjectSecretResponse struct {
 	CredentialsObject dataplane.CredentialsObject
 	Properties        DeletedSecretProperties
+}
+
+type DeletedNestedCredentialsObjectSecretResponse struct {
+	NestedCredentialsObject swagger.NestedCredentialsObject
+	Properties              DeletedSecretProperties
 }
 
 type MsiKeyVaultStore struct {
@@ -36,9 +42,24 @@ type SecretProperties struct {
 	NotBefore time.Time
 }
 
-type SecretResponse struct {
+type CredentialsObjectSecretResponse struct {
 	CredentialsObject dataplane.CredentialsObject
 	Properties        SecretProperties
+}
+
+type NestedCredentialsObjectSecretResponse struct {
+	NestedCredentialsObject swagger.NestedCredentialsObject
+	Properties              SecretProperties
+}
+
+type secretObject struct {
+	value      string
+	properties SecretProperties
+}
+
+type deletedSecretObject struct {
+	value      string
+	properties DeletedSecretProperties
 }
 
 func NewMsiKeyVaultStore(kvClient KeyVaultClient) *MsiKeyVaultStore {
@@ -47,7 +68,7 @@ func NewMsiKeyVaultStore(kvClient KeyVaultClient) *MsiKeyVaultStore {
 
 // Delete a credentials object from key vault using the specified secret name.
 // Delete applies to all versions of the secret.
-func (s *MsiKeyVaultStore) DeleteCredentialsObject(ctx context.Context, secretName string) error {
+func (s *MsiKeyVaultStore) DeleteSecret(ctx context.Context, secretName string) error {
 	if _, err := s.kvClient.DeleteSecret(ctx, secretName, nil); err != nil {
 		return err
 	}
@@ -57,7 +78,38 @@ func (s *MsiKeyVaultStore) DeleteCredentialsObject(ctx context.Context, secretNa
 
 // Get a credentials object from the key vault using the specified secret name.
 // The latest version of the secret will always be returned.
-func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName string) (*SecretResponse, error) {
+func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName string) (*CredentialsObjectSecretResponse, error) {
+	secretObject, err := s.getSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	var credentialsObject dataplane.CredentialsObject
+	if err := credentialsObject.UnmarshalJSON([]byte(secretObject.value)); err != nil {
+		return nil, err
+	}
+
+	return &CredentialsObjectSecretResponse{CredentialsObject: credentialsObject, Properties: secretObject.properties}, nil
+}
+
+// Get a nested credentials object from the key vault using the specified secret name.
+func (s *MsiKeyVaultStore) GetNestedCredentialsObject(ctx context.Context, secretName string) (*NestedCredentialsObjectSecretResponse, error) {
+	secretObject, err := s.getSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	var nestedCredentialsObject swagger.NestedCredentialsObject
+	if err := nestedCredentialsObject.UnmarshalJSON([]byte(secretObject.value)); err != nil {
+		return nil, err
+	}
+
+	return &NestedCredentialsObjectSecretResponse{NestedCredentialsObject: nestedCredentialsObject, Properties: secretObject.properties}, nil
+}
+
+// Get a secret from the key vault using the specified secret name.
+// The latest version of the secret will always be returned.
+func (s *MsiKeyVaultStore) getSecret(ctx context.Context, secretName string) (*secretObject, error) {
 	// https://github.com/Azure/azure-sdk-for-go/blob/3fab729f1bd43098837ddc34931fec6c342fa3ef/sdk/security/keyvault/azsecrets/client.go#L197
 	latestSecretVersion := ""
 	secret, err := s.kvClient.GetSecret(ctx, secretName, latestSecretVersion, nil)
@@ -67,10 +119,6 @@ func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName 
 
 	if secret.Value == nil {
 		return nil, errNilSecretValue
-	}
-	var credentialsObject dataplane.CredentialsObject
-	if err := credentialsObject.Values.UnmarshalJSON([]byte(*secret.Value)); err != nil {
-		return nil, err
 	}
 
 	secretProperties := SecretProperties{
@@ -92,12 +140,41 @@ func (s *MsiKeyVaultStore) GetCredentialsObject(ctx context.Context, secretName 
 			secretProperties.NotBefore = *secret.Attributes.NotBefore
 		}
 	}
-
-	return &SecretResponse{CredentialsObject: credentialsObject, Properties: secretProperties}, nil
+	return &secretObject{value: *secret.Value, properties: secretProperties}, nil
 }
 
 // Get a deleted credentials object from the key vault using the specified secret name.
-func (s *MsiKeyVaultStore) GetDeletedCredentialsObject(ctx context.Context, secretName string) (*DeletedSecretResponse, error) {
+func (s *MsiKeyVaultStore) GetDeletedCredentialsObject(ctx context.Context, secretName string) (*DeletedCredentialsObjectSecretResponse, error) {
+	deletedSecretObject, err := s.getDeletedSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	var credentialsObject dataplane.CredentialsObject
+	if err := credentialsObject.UnmarshalJSON([]byte(deletedSecretObject.value)); err != nil {
+		return nil, err
+	}
+
+	return &DeletedCredentialsObjectSecretResponse{CredentialsObject: credentialsObject, Properties: deletedSecretObject.properties}, nil
+}
+
+// Get a deleted nested credentials object from the key vault using the specified secret name.
+func (s *MsiKeyVaultStore) GetDeletedNestedCredentialsObject(ctx context.Context, secretName string) (*DeletedNestedCredentialsObjectSecretResponse, error) {
+	deletedSecretObject, err := s.getDeletedSecret(ctx, secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	var nestedCredentialsObject swagger.NestedCredentialsObject
+	if err := nestedCredentialsObject.UnmarshalJSON([]byte(deletedSecretObject.value)); err != nil {
+		return nil, err
+	}
+
+	return &DeletedNestedCredentialsObjectSecretResponse{NestedCredentialsObject: nestedCredentialsObject, Properties: deletedSecretObject.properties}, nil
+}
+
+// Get a deleted secret from the key vault using the specified secret name.
+func (s *MsiKeyVaultStore) getDeletedSecret(ctx context.Context, secretName string) (*deletedSecretObject, error) {
 	response, err := s.kvClient.GetDeletedSecret(ctx, secretName, nil)
 	if err != nil {
 		return nil, err
@@ -105,11 +182,6 @@ func (s *MsiKeyVaultStore) GetDeletedCredentialsObject(ctx context.Context, secr
 
 	if response.Value == nil {
 		return nil, errNilSecretValue
-	}
-
-	var creds dataplane.CredentialsObject
-	if err := creds.Values.UnmarshalJSON([]byte(*response.Value)); err != nil {
-		return nil, err
 	}
 
 	deletedSecretProperties := DeletedSecretProperties{
@@ -129,22 +201,22 @@ func (s *MsiKeyVaultStore) GetDeletedCredentialsObject(ctx context.Context, secr
 		}
 	}
 
-	return &DeletedSecretResponse{CredentialsObject: creds, Properties: deletedSecretProperties}, nil
+	return &deletedSecretObject{value: *response.Value, properties: deletedSecretProperties}, nil
 }
 
-// Get a pager for listing credentials objects from the key vault.
-func (s *MsiKeyVaultStore) GetCredentialsObjectPager() *runtime.Pager[azsecrets.ListSecretPropertiesResponse] {
+// Get a pager for listing Secret objects from the key vault.
+func (s *MsiKeyVaultStore) GetSecretObjectPager() *runtime.Pager[azsecrets.ListSecretPropertiesResponse] {
 	return s.kvClient.NewListSecretPropertiesPager(nil)
 }
 
-// Get a pager for listing deleted credentials objects from the key vault.
-func (s *MsiKeyVaultStore) GetDeletedCredentialsObjectPager() *runtime.Pager[azsecrets.ListDeletedSecretPropertiesResponse] {
+// Get a pager for listing deleted Secret objects from the key vault.
+func (s *MsiKeyVaultStore) GetDeletedSecretObjectPager() *runtime.Pager[azsecrets.ListDeletedSecretPropertiesResponse] {
 	return s.kvClient.NewListDeletedSecretPropertiesPager(nil)
 }
 
-// Purge a deleted credentials object from the key vault using the specified secret name.
+// Purge a deleted Secret object from the key vault using the specified secret name.
 // This operation is only applicable in vaults enabled for soft-delete.
-func (s *MsiKeyVaultStore) PurgeDeletedCredentialsObject(ctx context.Context, secretName string) error {
+func (s *MsiKeyVaultStore) PurgeDeletedSecretObject(ctx context.Context, secretName string) error {
 	if _, err := s.kvClient.PurgeDeletedSecret(ctx, secretName, nil); err != nil {
 		return err
 	}
@@ -153,16 +225,32 @@ func (s *MsiKeyVaultStore) PurgeDeletedCredentialsObject(ctx context.Context, se
 }
 
 // Set a credentials object in the key vault using the specified secret name.
-// If the secret already exists, key vault will create a new version of the secret.
 func (s *MsiKeyVaultStore) SetCredentialsObject(ctx context.Context, properties SecretProperties, credentialsObject dataplane.CredentialsObject) error {
-	credentialsObjectBuffer, err := credentialsObject.Values.MarshalJSON()
+	credentialsObjectBuffer, err := credentialsObject.MarshalJSON()
 	if err != nil {
 		return err
 	}
 
 	credentialsObjectString := string(credentialsObjectBuffer)
+	return s.setSecret(ctx, properties, &credentialsObjectString)
+}
+
+// Set a nested credentials object in the key vault using the specified secret name.
+func (s *MsiKeyVaultStore) SetNestedCredentialsObject(ctx context.Context, properties SecretProperties, nestedCredentialsObject swagger.NestedCredentialsObject) error {
+	nestedCredentialsObjectBuffer, err := nestedCredentialsObject.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	nestedCredentialsObjectString := string(nestedCredentialsObjectBuffer)
+	return s.setSecret(ctx, properties, &nestedCredentialsObjectString)
+}
+
+// Set a secret in the key vault using the specified secret name.
+// If the secret already exists, key vault will create a new version of the secret.
+func (s *MsiKeyVaultStore) setSecret(ctx context.Context, properties SecretProperties, secretValue *string) error {
 	setSecretParameters := azsecrets.SetSecretParameters{
-		Value: &credentialsObjectString,
+		Value: secretValue,
 		SecretAttributes: &azsecrets.SecretAttributes{
 			Enabled:   &properties.Enabled,
 			Expires:   &properties.Expires,

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -57,7 +57,7 @@ func TestDeleteCredentialsObject(t *testing.T) {
 			tc.goMockCall(kvClient)
 
 			kvStore := NewMsiKeyVaultStore(kvClient)
-			if err := kvStore.DeleteCredentialsObject(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
+			if err := kvStore.DeleteSecret(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}
 		})
@@ -262,7 +262,7 @@ func TestNewDeletedListSecretsPager(t *testing.T) {
 			tc.goMockCall(kvClient)
 
 			kvStore := NewMsiKeyVaultStore(kvClient)
-			if pager := kvStore.GetDeletedCredentialsObjectPager(); pager == nil {
+			if pager := kvStore.GetDeletedSecretObjectPager(); pager == nil {
 				t.Error("Expected pager but got nil")
 			}
 		})
@@ -295,7 +295,7 @@ func TestNewListSecretsPager(t *testing.T) {
 			tc.goMockCall(kvClient)
 
 			kvStore := NewMsiKeyVaultStore(kvClient)
-			if pager := kvStore.GetCredentialsObjectPager(); pager == nil {
+			if pager := kvStore.GetSecretObjectPager(); pager == nil {
 				t.Error("Expected pager but got nil")
 			}
 		})
@@ -336,7 +336,7 @@ func TestPurgeDeletedSecret(t *testing.T) {
 			tc.goMockCall(kvClient)
 
 			kvStore := NewMsiKeyVaultStore(kvClient)
-			if err := kvStore.PurgeDeletedCredentialsObject(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
+			if err := kvStore.PurgeDeletedSecretObject(context.Background(), mockSecretName); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}
 		})

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -68,6 +68,7 @@ func TestGetCredentialsObject(t *testing.T) {
 	t.Parallel()
 
 	bogusValue := test.Bogus
+	testNestedCredentialsObject := swagger.NestedCredentialsObject{}
 	testCredentialsObject := dataplane.CredentialsObject{
 		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
@@ -140,6 +141,101 @@ func TestGetCredentialsObject(t *testing.T) {
 				if !reflect.DeepEqual(testCredentialsObject, response.CredentialsObject) {
 					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
 				}
+				if !reflect.DeepEqual(testNestedCredentialsObject, response.NestedCredentialsObject) {
+					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
+				}
+				if response.Properties.Enabled != enabled {
+					t.Errorf("Expected enabled %t but got: %t", enabled, response.Properties.Enabled)
+				}
+				if !response.Properties.Expires.Equal(expires) {
+					t.Errorf("Expected expires %s but got: %s", expires, response.Properties.Expires)
+				}
+				if !response.Properties.NotBefore.Equal(notBefore) {
+					t.Errorf("Expected notBefore %s but got: %s", notBefore, response.Properties.NotBefore)
+				}
+			}
+		})
+	}
+}
+
+func TestGetNestedCredentialsObject(t *testing.T) {
+	t.Parallel()
+
+	bogusValue := test.Bogus
+	testCredentialsObject := dataplane.CredentialsObject{}
+	testNestedCredentialsObject := swagger.NestedCredentialsObject{
+		ClientSecret: &bogusValue,
+	}
+	testNestedCredentialsObjectBuffer, err := testNestedCredentialsObject.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to encode test nested credentials object: %s", err)
+	}
+	testNestedCredentialsObjectString := string(testNestedCredentialsObjectBuffer)
+	enabled := true
+	expires := time.Now()
+	notBefore := time.Now()
+	testGetSecretResponse := azsecrets.GetSecretResponse{
+		Secret: azsecrets.Secret{
+			Value: &testNestedCredentialsObjectString,
+			Attributes: &azsecrets.SecretAttributes{
+				Enabled:   &enabled,
+				Expires:   &expires,
+				NotBefore: &notBefore,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
+		expectedError error
+	}{
+		{
+			name: "Returns success when kv client successfully gets the secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().GetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testGetSecretResponse, nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Returns kv client error when kv client fails to get the secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().GetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.GetSecretResponse{}, errMock)
+			},
+			expectedError: errMock,
+		},
+		{
+			name: "Returns error when secret value is nil",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				resp := testGetSecretResponse
+				resp.Secret.Value = nil
+				kvClient.EXPECT().GetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
+			},
+			expectedError: errNilSecretValue,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
+			response, err := kvStore.GetNestedCredentialsObject(context.Background(), mockSecretName)
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
+			}
+			if err == nil {
+				if !reflect.DeepEqual(testCredentialsObject, response.CredentialsObject) {
+					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
+				}
+				if !reflect.DeepEqual(testNestedCredentialsObject, response.NestedCredentialsObject) {
+					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
+				}
 				if response.Properties.Enabled != enabled {
 					t.Errorf("Expected enabled %t but got: %t", enabled, response.Properties.Enabled)
 				}
@@ -158,6 +254,7 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 	t.Parallel()
 
 	bogusValue := test.Bogus
+	testNestedCredentialsObject := swagger.NestedCredentialsObject{}
 	testCredentialsObject := dataplane.CredentialsObject{
 		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
@@ -227,6 +324,93 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 			if err == nil {
 				if !reflect.DeepEqual(testCredentialsObject, response.CredentialsObject) {
 					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
+				}
+				if !reflect.DeepEqual(testNestedCredentialsObject, response.NestedCredentialsObject) {
+					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
+				}
+				if !response.Properties.DeletedDate.Equal(deletedDate) {
+					t.Errorf("Expected deletedDate %s but got: %s", deletedDate, response.Properties.DeletedDate)
+				}
+			}
+		})
+	}
+}
+
+func TestGetDeletedNestedCredentialsObject(t *testing.T) {
+	t.Parallel()
+
+	bogusValue := test.Bogus
+	testCredentialsObject := dataplane.CredentialsObject{}
+	testNestedCredentialsObject := swagger.NestedCredentialsObject{
+		ClientSecret: &bogusValue,
+	}
+	testNestedCredentialsObjectBuffer, err := testNestedCredentialsObject.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to encode test nested credentials object: %s", err)
+	}
+	testNestedCredentialsObjectString := string(testNestedCredentialsObjectBuffer)
+	deletedDate := time.Now()
+	recoveryLevel := "Purgable"
+	testGetDeletedSecretResponse := azsecrets.GetDeletedSecretResponse{
+		DeletedSecret: azsecrets.DeletedSecret{
+			Value: &testNestedCredentialsObjectString,
+			Attributes: &azsecrets.SecretAttributes{
+				RecoveryLevel: &recoveryLevel,
+			},
+			DeletedDate: &deletedDate,
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
+		expectedError error
+	}{
+		{
+			name: "Returns success when kv client successfully gets the deleted secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().GetDeletedSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(testGetDeletedSecretResponse, nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Returns kv client error when kv client fails to get the deleted secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().GetDeletedSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.GetDeletedSecretResponse{}, errMock)
+			},
+			expectedError: errMock,
+		},
+		{
+			name: "Returns error when secret value is nil",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				resp := testGetDeletedSecretResponse
+				resp.DeletedSecret.Value = nil
+				kvClient.EXPECT().GetDeletedSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(resp, nil)
+			},
+			expectedError: errNilSecretValue,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
+			response, err := kvStore.GetDeletedNestedCredentialsObject(context.Background(), mockSecretName)
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
+			}
+			if err == nil {
+				if !reflect.DeepEqual(testCredentialsObject, response.CredentialsObject) {
+					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
+				}
+				if !reflect.DeepEqual(testNestedCredentialsObject, response.NestedCredentialsObject) {
+					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
 				}
 				if !response.Properties.DeletedDate.Equal(deletedDate) {
 					t.Errorf("Expected deletedDate %s but got: %s", deletedDate, response.Properties.DeletedDate)
@@ -381,6 +565,50 @@ func TestSetCredentialsObject(t *testing.T) {
 				Name: mockSecretName,
 			}
 			if err := kvStore.SetCredentialsObject(context.Background(), props, dataplane.CredentialsObject{}); !errors.Is(err, tc.expectedError) {
+				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestSetNestedCredentialsObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		goMockCall    func(kvClient *mock.MockKeyVaultClient)
+		expectedError error
+	}{
+		{
+			name: "Returns success when kv client successfully sets the secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.SetSecretResponse{}, nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Returns kv client error when kv client fails to set the secret",
+			goMockCall: func(kvClient *mock.MockKeyVaultClient) {
+				kvClient.EXPECT().SetSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(azsecrets.SetSecretResponse{}, errMock)
+			},
+			expectedError: errMock,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			kvClient := mock.NewMockKeyVaultClient(mockCtrl)
+			tc.goMockCall(kvClient)
+
+			kvStore := NewMsiKeyVaultStore(kvClient)
+			props := SecretProperties{
+				Name: mockSecretName,
+			}
+			if err := kvStore.SetNestedCredentialsObject(context.Background(), props, swagger.NestedCredentialsObject{}); !errors.Is(err, tc.expectedError) {
 				t.Errorf("Expected %s but got: %s", tc.expectedError, err)
 			}
 		})

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -67,26 +67,35 @@ func TestDeleteCredentialsObject(t *testing.T) {
 func TestGetCredentialsObject(t *testing.T) {
 	t.Parallel()
 
+	enabled := true
+	expires := time.Now()
+	notBefore := time.Now()
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
 		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
+<<<<<<< HEAD
 	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
+=======
+
+	testCredentialsObjectSecretResponse := CredentialsObjectSecretResponse{
+		Properties: SecretProperties{
+			Enabled:   enabled,
+			Expires:   expires,
+			Name:      mockSecretName,
+			NotBefore: notBefore,
+		},
+		CredentialsObject: testCredentialsObject,
+	}
+
+	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
+>>>>>>> update UT to verify entire response
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}
 	testCredentialsObjectString := string(testCredentialsObjectBuffer)
-	enabled := true
-	expires := time.Now()
-	notBefore := time.Now()
-	testProperties := SecretProperties{
-		Enabled:   enabled,
-		Expires:   expires,
-		Name:      mockSecretName,
-		NotBefore: notBefore,
-	}
 	testGetSecretResponse := azsecrets.GetSecretResponse{
 		Secret: azsecrets.Secret{
 			Value: &testCredentialsObjectString,
@@ -143,11 +152,8 @@ func TestGetCredentialsObject(t *testing.T) {
 				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(response.CredentialsObject, testCredentialsObject); diff != "" {
-					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
-				}
-				if diff := cmp.Diff(response.Properties, testProperties); diff != "" {
-					t.Errorf("Expected credentials object properties %+v\n but got: %+v", testProperties, response.Properties)
+				if diff := cmp.Diff(response, &testCredentialsObjectSecretResponse); diff != "" {
+					t.Errorf("Expected credentials object response %+v\n but got: %+v", &testCredentialsObjectSecretResponse, response)
 				}
 			}
 		})
@@ -157,24 +163,29 @@ func TestGetCredentialsObject(t *testing.T) {
 func TestGetNestedCredentialsObject(t *testing.T) {
 	t.Parallel()
 
+	enabled := true
+	expires := time.Now()
+	notBefore := time.Now()
 	bogusValue := test.Bogus
 	testNestedCredentialsObject := swagger.NestedCredentialsObject{
 		ClientSecret: &bogusValue,
 	}
+
+	testNestedCredentialsObjectSecretResponse := NestedCredentialsObjectSecretResponse{
+		Properties: SecretProperties{
+			Enabled:   enabled,
+			Expires:   expires,
+			Name:      mockSecretName,
+			NotBefore: notBefore,
+		},
+		NestedCredentialsObject: testNestedCredentialsObject,
+	}
+
 	testNestedCredentialsObjectBuffer, err := testNestedCredentialsObject.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Failed to encode test nested credentials object: %s", err)
 	}
 	testNestedCredentialsObjectString := string(testNestedCredentialsObjectBuffer)
-	enabled := true
-	expires := time.Now()
-	notBefore := time.Now()
-	testProperties := SecretProperties{
-		Enabled:   enabled,
-		Expires:   expires,
-		Name:      mockSecretName,
-		NotBefore: notBefore,
-	}
 	testGetSecretResponse := azsecrets.GetSecretResponse{
 		Secret: azsecrets.Secret{
 			Value: &testNestedCredentialsObjectString,
@@ -231,11 +242,8 @@ func TestGetNestedCredentialsObject(t *testing.T) {
 				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(response.NestedCredentialsObject, testNestedCredentialsObject); diff != "" {
-					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
-				}
-				if diff := cmp.Diff(response.Properties, testProperties); diff != "" {
-					t.Errorf("Expected nested credentials object properties %+v\n but got: %+v", testProperties, response.Properties)
+				if diff := cmp.Diff(response, &testNestedCredentialsObjectSecretResponse); diff != "" {
+					t.Errorf("Expected nested credentials object %+v\n but got: %+v", &testNestedCredentialsObjectSecretResponse, response.NestedCredentialsObject)
 				}
 			}
 		})
@@ -245,19 +253,33 @@ func TestGetNestedCredentialsObject(t *testing.T) {
 func TestDeletedGetCredentialsObject(t *testing.T) {
 	t.Parallel()
 
+	deletedDate := time.Now()
+	recoveryLevel := "Purgable"
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
 		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
+<<<<<<< HEAD
 	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
+=======
+
+	testDeletedCredentialsObjectSecretResponse := DeletedCredentialsObjectSecretResponse{
+		Properties: DeletedSecretProperties{
+			Name:          mockSecretName,
+			RecoveryLevel: recoveryLevel,
+			DeletedDate:   deletedDate,
+		},
+		CredentialsObject: testCredentialsObject,
+	}
+
+	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
+>>>>>>> update UT to verify entire response
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}
 	testCredentialsObjectString := string(testCredentialsObjectBuffer)
-	deletedDate := time.Now()
-	recoveryLevel := "Purgable"
 	testGetDeletedSecretResponse := azsecrets.GetDeletedSecretResponse{
 		DeletedSecret: azsecrets.DeletedSecret{
 			Value: &testCredentialsObjectString,
@@ -313,11 +335,8 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(response.CredentialsObject, testCredentialsObject); diff != "" {
-					t.Errorf("Expected credentials object %+v\n but got: %+v", testCredentialsObject, response.CredentialsObject)
-				}
-				if !response.Properties.DeletedDate.Equal(deletedDate) {
-					t.Errorf("Expected deletedDate %s but got: %s", deletedDate, response.Properties.DeletedDate)
+				if diff := cmp.Diff(response, &testDeletedCredentialsObjectSecretResponse); diff != "" {
+					t.Errorf("Expected deleted credentials object response %+v\n but got: %+v", &testDeletedCredentialsObjectSecretResponse, response)
 				}
 			}
 		})
@@ -327,17 +346,27 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 func TestGetDeletedNestedCredentialsObject(t *testing.T) {
 	t.Parallel()
 
+	deletedDate := time.Now()
+	recoveryLevel := "Purgable"
 	bogusValue := test.Bogus
 	testNestedCredentialsObject := swagger.NestedCredentialsObject{
 		ClientSecret: &bogusValue,
 	}
+
+	testDeletedNestedCredentialsObjectSecretResponse := DeletedNestedCredentialsObjectSecretResponse{
+		Properties: DeletedSecretProperties{
+			Name:          mockSecretName,
+			RecoveryLevel: recoveryLevel,
+			DeletedDate:   deletedDate,
+		},
+		NestedCredentialsObject: testNestedCredentialsObject,
+	}
+
 	testNestedCredentialsObjectBuffer, err := testNestedCredentialsObject.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Failed to encode test nested credentials object: %s", err)
 	}
 	testNestedCredentialsObjectString := string(testNestedCredentialsObjectBuffer)
-	deletedDate := time.Now()
-	recoveryLevel := "Purgable"
 	testGetDeletedSecretResponse := azsecrets.GetDeletedSecretResponse{
 		DeletedSecret: azsecrets.DeletedSecret{
 			Value: &testNestedCredentialsObjectString,
@@ -393,11 +422,8 @@ func TestGetDeletedNestedCredentialsObject(t *testing.T) {
 				t.Errorf("Expected error %s but got: %s", tc.expectedError, err)
 			}
 			if err == nil {
-				if diff := cmp.Diff(response.NestedCredentialsObject, testNestedCredentialsObject); diff != "" {
-					t.Errorf("Expected nested credentials object %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
-				}
-				if !response.Properties.DeletedDate.Equal(deletedDate) {
-					t.Errorf("Expected deletedDate %s but got: %s", deletedDate, response.Properties.DeletedDate)
+				if diff := cmp.Diff(response, &testDeletedNestedCredentialsObjectSecretResponse); diff != "" {
+					t.Errorf("Expected deleted nested credentials object response %+v\n but got: %+v", testNestedCredentialsObject, response.NestedCredentialsObject)
 				}
 			}
 		})

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -72,7 +72,7 @@ func TestGetCredentialsObject(t *testing.T) {
 	notBefore := time.Now()
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		CredentialsObject: swagger.CredentialsObject{
+		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
@@ -87,7 +87,7 @@ func TestGetCredentialsObject(t *testing.T) {
 		CredentialsObject: testCredentialsObject,
 	}
 
-	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
+	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}
@@ -253,7 +253,7 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 	recoveryLevel := "Purgable"
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		CredentialsObject: swagger.CredentialsObject{
+		Values: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
@@ -267,7 +267,7 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 		CredentialsObject: testCredentialsObject,
 	}
 
-	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
+	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -72,13 +72,10 @@ func TestGetCredentialsObject(t *testing.T) {
 	notBefore := time.Now()
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		Values: swagger.CredentialsObject{
+		CredentialsObject: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
-<<<<<<< HEAD
-	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
-=======
 
 	testCredentialsObjectSecretResponse := CredentialsObjectSecretResponse{
 		Properties: SecretProperties{
@@ -91,7 +88,6 @@ func TestGetCredentialsObject(t *testing.T) {
 	}
 
 	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
->>>>>>> update UT to verify entire response
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}
@@ -257,13 +253,10 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 	recoveryLevel := "Purgable"
 	bogusValue := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		Values: swagger.CredentialsObject{
+		CredentialsObject: swagger.CredentialsObject{
 			ClientSecret: &bogusValue,
 		},
 	}
-<<<<<<< HEAD
-	testCredentialsObjectBuffer, err := testCredentialsObject.Values.MarshalJSON()
-=======
 
 	testDeletedCredentialsObjectSecretResponse := DeletedCredentialsObjectSecretResponse{
 		Properties: DeletedSecretProperties{
@@ -275,7 +268,6 @@ func TestDeletedGetCredentialsObject(t *testing.T) {
 	}
 
 	testCredentialsObjectBuffer, err := testCredentialsObject.MarshalJSON()
->>>>>>> update UT to verify entire response
 	if err != nil {
 		t.Fatalf("Failed to encode test credentials object: %s", err)
 	}

--- a/test/integration/cassettes/store.yaml
+++ b/test/integration/cassettes/store.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-g5n54x.vault.azure.net
+        host: vcr-kv-j8x2oz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -18,12 +18,12 @@ interactions:
             Accept:
                 - application/json
             Content-Length:
-                - "37"
+                - "101"
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.22.2; linux)
-        url: https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
+        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -42,7 +42,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 26 Apr 2024 07:45:36 GMT
+                - Thu, 02 Jan 2025 20:24:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -50,43 +50,43 @@ interactions:
             Strict-Transport-Security:
                 - max-age=31536000;includeSubDomains
             Www-Authenticate:
-                - Bearer authorization="https://login.microsoftonline.com/17820104-2f75-41cc-bac0-4c79f86f1499", resource="https://vault.azure.net"
+                - Bearer authorization="https://login.microsoftonline.com/93b21e64-4824-439a-b893-46c9b2a51082", resource="https://vault.azure.net"
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Keyvault-Network-Info:
-                - conn_type=Ipv4;addr=24.19.121.216;act_addr_fam=InterNetwork;
+                - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
-                - 1.9.1430.1
+                - 1.9.1988.1
             X-Ms-Request-Id:
-                - 86c39051-bf0b-40a1-b246-b2c621261f73
+                - 96c1736b-006d-4cd1-83f3-045c8d9a0f6f
         status: 401 Unauthorized
         code: 401
-        duration: 422.745486ms
+        duration: 204.81937ms
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 37
+        content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-g5n54x.vault.azure.net
+        host: vcr-kv-j8x2oz.vault.azure.net
         remote_addr: ""
         request_uri: ""
-        body: '{"value":"{\"client_id\":\"bogus\"}"}'
+        body: '{"attributes":{"enabled":true,"exp":1735853042,"nbf":1735849442},"value":"{\"client_id\":\"bogus\"}"}'
         form: {}
         headers:
             Accept:
                 - application/json
             Content-Length:
-                - "37"
+                - "101"
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.22.2; linux)
-        url: https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
+        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -94,18 +94,18 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 262
+        content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus/546fe9be85f543fdb4540352e9b74e61","attributes":{"enabled":true,"created":1714117539,"updated":1714117539,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "262"
+                - "296"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 26 Apr 2024 07:45:38 GMT
+                - Thu, 02 Jan 2025 20:24:04 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -115,18 +115,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Keyvault-Network-Info:
-                - conn_type=Ipv4;addr=24.19.121.216;act_addr_fam=InterNetwork;
+                - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e2f1815862ad4add978d30b7a9a5ced9
+                - a2056dc519354432839990bec7a32cad
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
-                - 1.9.1430.1
+                - 1.9.1988.1
             X-Ms-Request-Id:
-                - 852d401c-4114-43d3-a06b-a669006bbec5
+                - 8e695325-9e39-4a32-965e-21b5879187c2
         status: 200 OK
         code: 200
-        duration: 254.687898ms
+        duration: 163.074078ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -135,7 +135,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-g5n54x.vault.azure.net
+        host: vcr-kv-j8x2oz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -144,8 +144,8 @@ interactions:
             Accept:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.22.2; linux)
-        url: https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus/?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
+        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/?api-version=7.5
         method: GET
       response:
         proto: HTTP/1.1
@@ -153,18 +153,18 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 262
+        content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus/546fe9be85f543fdb4540352e9b74e61","attributes":{"enabled":true,"created":1714117539,"updated":1714117539,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "262"
+                - "296"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 26 Apr 2024 07:45:38 GMT
+                - Thu, 02 Jan 2025 20:24:05 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -174,18 +174,18 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Keyvault-Network-Info:
-                - conn_type=Ipv4;addr=24.19.121.216;act_addr_fam=InterNetwork;
+                - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e2f1815862ad4add978d30b7a9a5ced9
+                - a2056dc519354432839990bec7a32cad
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
-                - 1.9.1430.1
+                - 1.9.1988.1
             X-Ms-Request-Id:
-                - 9b965206-6394-4af8-bc2a-c46f5d373747
+                - 1675ac1c-7d2a-411e-9191-a1507efe24ef
         status: 200 OK
         code: 200
-        duration: 105.38185ms
+        duration: 75.448211ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-g5n54x.vault.azure.net
+        host: vcr-kv-j8x2oz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -203,8 +203,8 @@ interactions:
             Accept:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.22.2; linux)
-        url: https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
+        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -212,18 +212,18 @@ interactions:
         proto_minor: 1
         transfer_encoding: []
         trailer: {}
-        content_length: 357
+        content_length: 391
         uncompressed: false
-        body: '{"recoveryId":"https://vcr-kv-g5n54x.vault.azure.net/deletedsecrets/bogus","deletedDate":1714117539,"scheduledPurgeDate":1721893539,"id":"https://vcr-kv-g5n54x.vault.azure.net/secrets/bogus/546fe9be85f543fdb4540352e9b74e61","attributes":{"enabled":true,"created":1714117539,"updated":1714117539,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"recoveryId":"https://vcr-kv-j8x2oz.vault.azure.net/deletedsecrets/bogus","deletedDate":1735849445,"scheduledPurgeDate":1743625445,"id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
             Content-Length:
-                - "357"
+                - "391"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Fri, 26 Apr 2024 07:45:38 GMT
+                - Thu, 02 Jan 2025 20:24:05 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -233,15 +233,15 @@ interactions:
             X-Content-Type-Options:
                 - nosniff
             X-Ms-Keyvault-Network-Info:
-                - conn_type=Ipv4;addr=24.19.121.216;act_addr_fam=InterNetwork;
+                - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e2f1815862ad4add978d30b7a9a5ced9
+                - a2056dc519354432839990bec7a32cad
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
-                - 1.9.1430.1
+                - 1.9.1988.1
             X-Ms-Request-Id:
-                - a22b0c80-c2c6-4c49-861c-4a58e90969a4
+                - 26e41cbf-6f90-4b86-a243-124f29b7d47b
         status: 200 OK
         code: 200
-        duration: 140.402818ms
+        duration: 99.478002ms

--- a/test/integration/cassettes/store.yaml
+++ b/test/integration/cassettes/store.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-j8x2oz.vault.azure.net
+        host: vcr-kv-ngkzwz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -23,7 +23,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
+        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -42,7 +42,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 20:24:04 GMT
+                - Thu, 02 Jan 2025 22:32:18 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -60,10 +60,10 @@ interactions:
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - 96c1736b-006d-4cd1-83f3-045c8d9a0f6f
+                - fc246ee3-bf7e-4f7b-ad6d-4e64630ed400
         status: 401 Unauthorized
         code: 401
-        duration: 204.81937ms
+        duration: 245.151442ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -72,10 +72,10 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-j8x2oz.vault.azure.net
+        host: vcr-kv-ngkzwz.vault.azure.net
         remote_addr: ""
         request_uri: ""
-        body: '{"attributes":{"enabled":true,"exp":1735853042,"nbf":1735849442},"value":"{\"client_id\":\"bogus\"}"}'
+        body: '{"attributes":{"enabled":true,"exp":1735860737,"nbf":1735857137},"value":"{\"client_id\":\"bogus\"}"}'
         form: {}
         headers:
             Accept:
@@ -86,7 +86,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
+        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -96,7 +96,7 @@ interactions:
         trailer: {}
         content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 20:24:04 GMT
+                - Thu, 02 Jan 2025 22:32:19 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -117,16 +117,16 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - a2056dc519354432839990bec7a32cad
+                - e464696d2a194c82974fe4b975029fed
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - 8e695325-9e39-4a32-965e-21b5879187c2
+                - e1970f6c-5d44-4416-952c-a1eeddf429bb
         status: 200 OK
         code: 200
-        duration: 163.074078ms
+        duration: 168.129551ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -135,7 +135,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-j8x2oz.vault.azure.net
+        host: vcr-kv-ngkzwz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -145,7 +145,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/?api-version=7.5
+        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/?api-version=7.5
         method: GET
       response:
         proto: HTTP/1.1
@@ -155,7 +155,7 @@ interactions:
         trailer: {}
         content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -164,7 +164,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 20:24:05 GMT
+                - Thu, 02 Jan 2025 22:32:19 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -176,16 +176,16 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - a2056dc519354432839990bec7a32cad
+                - e464696d2a194c82974fe4b975029fed
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - 1675ac1c-7d2a-411e-9191-a1507efe24ef
+                - 9925467f-bf71-429f-b5ab-f263e312bd5c
         status: 200 OK
         code: 200
-        duration: 75.448211ms
+        duration: 79.493134ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-j8x2oz.vault.azure.net
+        host: vcr-kv-ngkzwz.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -204,7 +204,7 @@ interactions:
                 - application/json
             User-Agent:
                 - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus?api-version=7.5
+        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -214,7 +214,7 @@ interactions:
         trailer: {}
         content_length: 391
         uncompressed: false
-        body: '{"recoveryId":"https://vcr-kv-j8x2oz.vault.azure.net/deletedsecrets/bogus","deletedDate":1735849445,"scheduledPurgeDate":1743625445,"id":"https://vcr-kv-j8x2oz.vault.azure.net/secrets/bogus/4bcb7669bc004fb7b5a50d05096b4d5a","attributes":{"enabled":true,"nbf":1735849442,"exp":1735853042,"created":1735849444,"updated":1735849444,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"recoveryId":"https://vcr-kv-ngkzwz.vault.azure.net/deletedsecrets/bogus","deletedDate":1735857140,"scheduledPurgeDate":1743633140,"id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -223,7 +223,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 20:24:05 GMT
+                - Thu, 02 Jan 2025 22:32:19 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -235,13 +235,13 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - a2056dc519354432839990bec7a32cad
+                - e464696d2a194c82974fe4b975029fed
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - 26e41cbf-6f90-4b86-a243-124f29b7d47b
+                - fe9a6eca-e728-4467-b169-a766d7143d45
         status: 200 OK
         code: 200
-        duration: 99.478002ms
+        duration: 108.485722ms

--- a/test/integration/cassettes/store.yaml
+++ b/test/integration/cassettes/store.yaml
@@ -9,7 +9,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-ngkzwz.vault.azure.net
+        host: vcr-kv-kfsepq.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -22,8 +22,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.22.5; linux)
+        url: https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -42,7 +42,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 22:32:18 GMT
+                - Fri, 10 Jan 2025 16:52:50 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -60,10 +60,10 @@ interactions:
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - fc246ee3-bf7e-4f7b-ad6d-4e64630ed400
+                - 82c2e3e6-e221-4a2e-b69b-a7c955b09761
         status: 401 Unauthorized
         code: 401
-        duration: 245.151442ms
+        duration: 303.228184ms
     - id: 1
       request:
         proto: HTTP/1.1
@@ -72,10 +72,10 @@ interactions:
         content_length: 101
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-ngkzwz.vault.azure.net
+        host: vcr-kv-kfsepq.vault.azure.net
         remote_addr: ""
         request_uri: ""
-        body: '{"attributes":{"enabled":true,"exp":1735860737,"nbf":1735857137},"value":"{\"client_id\":\"bogus\"}"}'
+        body: '{"attributes":{"enabled":true,"exp":1736531570,"nbf":1736527970},"value":"{\"client_id\":\"bogus\"}"}'
         form: {}
         headers:
             Accept:
@@ -85,8 +85,8 @@ interactions:
             Content-Type:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.22.5; linux)
+        url: https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus?api-version=7.5
         method: PUT
       response:
         proto: HTTP/1.1
@@ -96,7 +96,7 @@ interactions:
         trailer: {}
         content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus/c49ee97c87e34e9ab507ed3c00f2ac6d","attributes":{"enabled":true,"nbf":1736527970,"exp":1736531570,"created":1736527971,"updated":1736527971,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -105,7 +105,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 22:32:19 GMT
+                - Fri, 10 Jan 2025 16:52:51 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -117,16 +117,16 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e464696d2a194c82974fe4b975029fed
+                - 9abf893b830b470292936b89cad28967
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - e1970f6c-5d44-4416-952c-a1eeddf429bb
+                - ca92c917-0ecf-4937-b560-f5b9b0435c23
         status: 200 OK
         code: 200
-        duration: 168.129551ms
+        duration: 191.433438ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -135,7 +135,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-ngkzwz.vault.azure.net
+        host: vcr-kv-kfsepq.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -144,8 +144,8 @@ interactions:
             Accept:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.22.5; linux)
+        url: https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus/?api-version=7.5
         method: GET
       response:
         proto: HTTP/1.1
@@ -155,7 +155,7 @@ interactions:
         trailer: {}
         content_length: 296
         uncompressed: false
-        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"value":"{\"client_id\":\"bogus\"}","id":"https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus/c49ee97c87e34e9ab507ed3c00f2ac6d","attributes":{"enabled":true,"nbf":1736527970,"exp":1736531570,"created":1736527971,"updated":1736527971,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -164,7 +164,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 22:32:19 GMT
+                - Fri, 10 Jan 2025 16:52:51 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -176,16 +176,16 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e464696d2a194c82974fe4b975029fed
+                - 9abf893b830b470292936b89cad28967
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - 9925467f-bf71-429f-b5ab-f263e312bd5c
+                - 1beaccc8-96c8-4f93-bf26-9cdc3207fd02
         status: 200 OK
         code: 200
-        duration: 79.493134ms
+        duration: 99.776021ms
     - id: 3
       request:
         proto: HTTP/1.1
@@ -194,7 +194,7 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: vcr-kv-ngkzwz.vault.azure.net
+        host: vcr-kv-kfsepq.vault.azure.net
         remote_addr: ""
         request_uri: ""
         body: ""
@@ -203,8 +203,8 @@ interactions:
             Accept:
                 - application/json
             User-Agent:
-                - azsdk-go-azsecrets/v1.1.0 (go1.21.13; linux)
-        url: https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus?api-version=7.5
+                - azsdk-go-azsecrets/v1.1.0 (go1.22.5; linux)
+        url: https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus?api-version=7.5
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -214,7 +214,7 @@ interactions:
         trailer: {}
         content_length: 391
         uncompressed: false
-        body: '{"recoveryId":"https://vcr-kv-ngkzwz.vault.azure.net/deletedsecrets/bogus","deletedDate":1735857140,"scheduledPurgeDate":1743633140,"id":"https://vcr-kv-ngkzwz.vault.azure.net/secrets/bogus/bfd57f900d4d4c208a72f4019e19b563","attributes":{"enabled":true,"nbf":1735857137,"exp":1735860737,"created":1735857140,"updated":1735857140,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
+        body: '{"recoveryId":"https://vcr-kv-kfsepq.vault.azure.net/deletedsecrets/bogus","deletedDate":1736527971,"scheduledPurgeDate":1744303971,"id":"https://vcr-kv-kfsepq.vault.azure.net/secrets/bogus/c49ee97c87e34e9ab507ed3c00f2ac6d","attributes":{"enabled":true,"nbf":1736527970,"exp":1736531570,"created":1736527971,"updated":1736527971,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}'
         headers:
             Cache-Control:
                 - no-cache
@@ -223,7 +223,7 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 02 Jan 2025 22:32:19 GMT
+                - Fri, 10 Jan 2025 16:52:51 GMT
             Expires:
                 - "-1"
             Pragma:
@@ -235,13 +235,13 @@ interactions:
             X-Ms-Keyvault-Network-Info:
                 - conn_type=Ipv4;addr=75.28.17.175;act_addr_fam=InterNetwork;
             X-Ms-Keyvault-Rbac-Assignment-Id:
-                - e464696d2a194c82974fe4b975029fed
+                - 9abf893b830b470292936b89cad28967
             X-Ms-Keyvault-Region:
                 - eastus
             X-Ms-Keyvault-Service-Version:
                 - 1.9.1988.1
             X-Ms-Request-Id:
-                - fe9a6eca-e728-4467-b169-a766d7143d45
+                - 90e98b00-9d14-4fe0-b27a-9f19d4c30927
         status: 200 OK
         code: 200
-        duration: 108.485722ms
+        duration: 126.970603ms

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"os"
+	"os/signal"
 	"path"
 	"testing"
 	"time"
@@ -31,6 +32,9 @@ const (
 
 func TestStore(t *testing.T) {
 	t.Parallel()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 
 	recordMode := getRecordMode()
 
@@ -88,13 +92,13 @@ func TestStore(t *testing.T) {
 		CredentialsObject: testCredentialsObject,
 	}
 
-	if err := msiStore.SetCredentialsObject(context.Background(), props, testCredentialsObject); err != nil {
+	if err := msiStore.SetCredentialsObject(ctx, props, testCredentialsObject); err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to set credentials object: %s", err)
 	}
 
 	// Get the credentials object from the store
-	resp, err := msiStore.GetCredentialsObject(context.Background(), bogus)
+	resp, err := msiStore.GetCredentialsObject(ctx, bogus)
 	if err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to get credentials object: %s", err)
@@ -111,13 +115,16 @@ func TestStore(t *testing.T) {
 	}
 
 	// Delete the credentials object from the store
-	if err := msiStore.DeleteSecret(context.Background(), bogus); err != nil {
+	if err := msiStore.DeleteSecret(ctx, bogus); err != nil {
 		t.Errorf("Failed to delete credentials object: %s", err)
 	}
 }
 
 func TestNestedCredentialsObjectStore(t *testing.T) {
 	t.Parallel()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 
 	recordMode := getRecordMode()
 
@@ -173,13 +180,13 @@ func TestNestedCredentialsObjectStore(t *testing.T) {
 		NestedCredentialsObject: testNestedCredentialsObject,
 	}
 
-	if err := msiStore.SetNestedCredentialsObject(context.Background(), props, testNestedCredentialsObject); err != nil {
+	if err := msiStore.SetNestedCredentialsObject(ctx, props, testNestedCredentialsObject); err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to set nested credentials object: %s", err)
 	}
 
 	// Get the credentials object from the store
-	resp, err := msiStore.GetNestedCredentialsObject(context.Background(), bogus)
+	resp, err := msiStore.GetNestedCredentialsObject(ctx, bogus)
 	if err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to get nested credentials object: %s", err)
@@ -190,7 +197,7 @@ func TestNestedCredentialsObjectStore(t *testing.T) {
 	}
 
 	// Delete the credentials object from the store
-	if err := msiStore.DeleteSecret(context.Background(), bogus); err != nil {
+	if err := msiStore.DeleteSecret(ctx, bogus); err != nil {
 		t.Errorf("Failed to nested delete credentials object: %s", err)
 	}
 }

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -68,7 +68,7 @@ func TestStore(t *testing.T) {
 	// Add a test credentials object to the store
 	bogus := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		Values: swagger.CredentialsObject{
+		CredentialsObject: swagger.CredentialsObject{
 			ClientID: &bogus,
 		},
 	}
@@ -104,14 +104,8 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Failed to get credentials object: %s", err)
 	}
 
-<<<<<<< HEAD
-	if !reflect.DeepEqual(testCredentialsObject, resp.CredentialsObject) {
-		t.Errorf(`Credential objects do not match. 
-		          Returned has client ID %s, expected %s`, *resp.CredentialsObject.Values.ClientID, *testCredentialsObject.Values.ClientID)
-=======
 	if diff := cmp.Diff(resp, &testCredentialsObjectSecretResponse); diff != "" {
 		t.Errorf("Expected credentials object %+v\n but got: %+v", &testCredentialsObjectSecretResponse, resp)
->>>>>>> update integration test
 	}
 
 	// Delete the credentials object from the store

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -89,7 +89,7 @@ func TestStore(t *testing.T) {
 	}
 
 	// Delete the credentials object from the store
-	if err := msiStore.DeleteCredentialsObject(context.Background(), bogus); err != nil {
+	if err := msiStore.DeleteSecret(context.Background(), bogus); err != nil {
 		t.Errorf("Failed to delete credentials object: %s", err)
 	}
 }

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 	"path"
-	"reflect"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
 	"github.com/Azure/msi-dataplane/pkg/dataplane/swagger"
 	"github.com/Azure/msi-dataplane/pkg/store"
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/dnaeon/go-vcr.v3/cassette"
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
@@ -67,10 +68,26 @@ func TestStore(t *testing.T) {
 			ClientID: &bogus,
 		},
 	}
-
-	props := store.SecretProperties{
-		Name: test.Bogus,
+	expirationDate, err := time.Parse(time.RFC3339, time.Now().Add(time.Hour).Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse expiry date: %s", err)
 	}
+	notBeforeDate, err := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse notBefore date: %s", err)
+	}
+	props := store.SecretProperties{
+		Name:      bogus,
+		Enabled:   true,
+		Expires:   expirationDate,
+		NotBefore: notBeforeDate,
+	}
+
+	testCredentialsObjectSecretResponse := store.CredentialsObjectSecretResponse{
+		Properties:        props,
+		CredentialsObject: testCredentialsObject,
+	}
+
 	if err := msiStore.SetCredentialsObject(context.Background(), props, testCredentialsObject); err != nil {
 		// Fatal here since rest of test cannot proceed
 		t.Fatalf("Failed to set credentials object: %s", err)
@@ -83,14 +100,98 @@ func TestStore(t *testing.T) {
 		t.Fatalf("Failed to get credentials object: %s", err)
 	}
 
+<<<<<<< HEAD
 	if !reflect.DeepEqual(testCredentialsObject, resp.CredentialsObject) {
 		t.Errorf(`Credential objects do not match. 
 		          Returned has client ID %s, expected %s`, *resp.CredentialsObject.Values.ClientID, *testCredentialsObject.Values.ClientID)
+=======
+	if diff := cmp.Diff(resp, &testCredentialsObjectSecretResponse); diff != "" {
+		t.Errorf("Expected credentials object %+v\n but got: %+v", &testCredentialsObjectSecretResponse, resp)
+>>>>>>> update integration test
 	}
 
 	// Delete the credentials object from the store
 	if err := msiStore.DeleteSecret(context.Background(), bogus); err != nil {
 		t.Errorf("Failed to delete credentials object: %s", err)
+	}
+}
+
+func TestNestedCredentialsObjectStore(t *testing.T) {
+	t.Parallel()
+
+	recordMode := getRecordMode()
+
+	// Get the credential based on record mode
+	var cred azcore.TokenCredential
+	var err error
+	switch recordMode {
+	case recorder.ModeReplayOnly:
+		// Use a fake credential for replay mode
+		cred = &test.FakeCredential{}
+	case recorder.ModeRecordOnly:
+		// Use the default Azure credential for record mode
+		cred, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			t.Fatalf("Failed to create credential: %s", err)
+		}
+	}
+
+	// Create a recorder for the secrets client
+	r, err := getRecorder(recordMode, getCassettePath())
+	if err != nil {
+		t.Fatalf("Failed to create recorder: %s", err)
+	}
+	defer r.Stop()
+
+	msiStore, err := createMsiStore(r, cred)
+	if err != nil {
+		t.Fatalf("Failed to create MSI store: %s", err)
+	}
+
+	// Add a test nested credentials object to the store
+	bogus := "NestedBogus"
+	testNestedCredentialsObject := swagger.NestedCredentialsObject{
+		ClientSecret: &bogus,
+	}
+	expirationDate, err := time.Parse(time.RFC3339, time.Now().Add(time.Hour).Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse expiry date: %s", err)
+	}
+	notBeforeDate, err := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("Failed to parse notBefore date: %s", err)
+	}
+	props := store.SecretProperties{
+		Name:      bogus,
+		Enabled:   true,
+		Expires:   expirationDate,
+		NotBefore: notBeforeDate,
+	}
+
+	testNestedCredentialsObjectSecretResponse := store.NestedCredentialsObjectSecretResponse{
+		Properties:              props,
+		NestedCredentialsObject: testNestedCredentialsObject,
+	}
+
+	if err := msiStore.SetNestedCredentialsObject(context.Background(), props, testNestedCredentialsObject); err != nil {
+		// Fatal here since rest of test cannot proceed
+		t.Fatalf("Failed to set nested credentials object: %s", err)
+	}
+
+	// Get the credentials object from the store
+	resp, err := msiStore.GetNestedCredentialsObject(context.Background(), bogus)
+	if err != nil {
+		// Fatal here since rest of test cannot proceed
+		t.Fatalf("Failed to get nested credentials object: %s", err)
+	}
+
+	if diff := cmp.Diff(resp, &testNestedCredentialsObjectSecretResponse); diff != "" {
+		t.Errorf("Expected nested credentials object %+v\n but got: %+v", &testNestedCredentialsObjectSecretResponse, resp)
+	}
+
+	// Delete the credentials object from the store
+	if err := msiStore.DeleteSecret(context.Background(), bogus); err != nil {
+		t.Errorf("Failed to nested delete credentials object: %s", err)
 	}
 }
 

--- a/test/integration/store_test.go
+++ b/test/integration/store_test.go
@@ -68,7 +68,7 @@ func TestStore(t *testing.T) {
 	// Add a test credentials object to the store
 	bogus := test.Bogus
 	testCredentialsObject := dataplane.CredentialsObject{
-		CredentialsObject: swagger.CredentialsObject{
+		Values: swagger.CredentialsObject{
 			ClientID: &bogus,
 		},
 	}


### PR DESCRIPTION
**JIRA link:**
https://issues.redhat.com/browse/ARO-11172

**What does this PR do?**
This PR adds following interfaces to support operations on nested credentials as outlined [in the DDR](https://docs.google.com/document/d/1tX2avo8ORyjqL4GJNwxq-wQTM3-LC7zBTP5V9EgwU74/edit?tab=t.0).
- Interfaces:
   - `GetNestedCredentialsObject`
   - `GetDeletedNestedCredentialsObject`
   - `SetNestedCredentialsObject`
- Objects:
   - `secretObject`
   - `deletedSecretObject`

**Testing:**
- New unit tests are added to cover the new interfaces and objects.