### PR TITLE
.github: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @niontive @weinong @bennerv @cadenmarchese @carvalhe @gouthamMN @hlipsig @kimorris27 @rajdeepc2792 
+* @niontive @weinong @bennerv @cadenmarchese @carvalhe @gouthamMN @hlipsig @kimorris27 @stevekuznetsov


### PR DESCRIPTION
Rajdeep did not have access to the repo, so the GitHub UI was complaining that adding them to this file was in error.

Adding myself as Nic has moved on to other projects.