### PR TITLE
Return Top level Cred Object

### DIFF
--- a/pkg/dataplane/client.go
+++ b/pkg/dataplane/client.go
@@ -48,7 +48,6 @@ var (
 	errInvalidRequest = errors.New("invalid request")
 	errNilMSI         = errors.New("expected non-nil user-assigned managed identity")
 	errNumberOfMSIs   = errors.New("returned MSIs does not match number of requested MSIs")
-	errGetNestedCreds = errors.New("failed to get nested credentials object")
 )
 
 // TODO - Add parameter to specify module name in azcore.NewClient()
@@ -74,7 +73,7 @@ func NewClient(cloud string, authenticator policy.Policy, clientOpts *policy.Cli
 	return &ManagedIdentityClient{swaggerClient: swaggerClient, cloud: cloud}, nil
 }
 
-func (c *ManagedIdentityClient) getUserAssignedIdentities(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
+func (c *ManagedIdentityClient) GetUserAssignedIdentities(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	validate.RegisterValidation(resourceIDsTag, validateResourceIDs)
 	if err := validate.Struct(request); err != nil {
@@ -107,29 +106,11 @@ func (c *ManagedIdentityClient) getUserAssignedIdentities(ctx context.Context, r
 		}
 	}
 
-	credentialsObject := CredentialsObject{Values: creds.CredentialsObject, cloud: c.cloud}
+	credentialsObject := CredentialsObject{Values: creds.CredentialsObject, Cloud: c.cloud}
 	if !credentialsObject.IsUserAssigned() {
 		return nil, errNoUserAssignedMSIs
 	}
 	return &credentialsObject, nil
-}
-
-func (c *ManagedIdentityClient) GetCredentialsObjectUserAssignedIdentities(ctx context.Context, request UserAssignedMSIRequest) (*CredentialsObject, error) {
-	return c.getUserAssignedIdentities(ctx, request)
-}
-
-func (c *ManagedIdentityClient) GetNestedCredentialsObjectUserAssignedIdentities(ctx context.Context, request UserAssignedMSIRequest) (*NestedCredentialsObject, error) {
-	ua, err := c.getUserAssignedIdentities(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(ua.Values.ExplicitIdentities) == 0 ||
-		ua.Values.ExplicitIdentities[0] == nil {
-		return nil, errGetNestedCreds
-	}
-
-	return &NestedCredentialsObject{Values: *ua.Values.ExplicitIdentities[0], cloud: c.cloud}, nil
 }
 
 func validateResourceIDs(fl validator.FieldLevel) bool {

--- a/pkg/dataplane/client_test.go
+++ b/pkg/dataplane/client_test.go
@@ -156,7 +156,7 @@ func TestGetUserAssignedIdentities(t *testing.T) {
 			tc.goMockCall(swaggerClient)
 
 			msiClient := &ManagedIdentityClient{swaggerClient: swaggerClient}
-			if _, err := msiClient.GetCredentialsObjectUserAssignedIdentities(context.Background(), tc.request); !errors.Is(err, tc.expectedErr) {
+			if _, err := msiClient.GetUserAssignedIdentities(context.Background(), tc.request); !errors.Is(err, tc.expectedErr) {
 				t.Errorf("expected error: `%s` but got: `%s`", tc.expectedErr, err)
 			}
 		})

--- a/pkg/dataplane/identity.go
+++ b/pkg/dataplane/identity.go
@@ -27,14 +27,14 @@ var (
 // swagger.Credentials object can represent either system or user-assigned managed identity
 type CredentialsObject struct {
 	Values swagger.CredentialsObject
-	cloud  string
+	Cloud  string
 }
 
 // NestedCredentialsObject is a wrapper around the swagger.NestedCredentialsObject to add additional functionality
 // swagger.NestedCredentials object can represent only user-assigned managed identity
 type NestedCredentialsObject struct {
 	Values swagger.NestedCredentialsObject
-	cloud  string
+	Cloud  string
 }
 
 // This method may be used by clients to check if they can use the object as a user-assigned managed identity
@@ -59,7 +59,7 @@ func (c CredentialsObject) GetCredential(requestedResourceID string) (*azidentit
 				return nil, fmt.Errorf("%w for identity resource ID %s: %w", errParseResourceID, *id.ResourceID, err)
 			}
 			if requestedResourceID == idARMResourceID.String() {
-				return getClientCertificateCredential(*id, c.cloud)
+				return getClientCertificateCredential(*id, c.Cloud)
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func (c CredentialsObject) GetCredential(requestedResourceID string) (*azidentit
 // Clients can use the credential to get a token for the user-assigned identity
 func (n NestedCredentialsObject) GetCredential() (*azidentity.ClientCertificateCredential, error) {
 	if n.Values.ResourceID != nil {
-		return getClientCertificateCredential(n.Values, n.cloud)
+		return getClientCertificateCredential(n.Values, n.Cloud)
 	}
 
 	return nil, errResourceIDNotFound

--- a/pkg/dataplane/stub_test.go
+++ b/pkg/dataplane/stub_test.go
@@ -197,7 +197,7 @@ func TestStubWithClient(t *testing.T) {
 		IdentityURL: test.ValidIdentityURL,
 		TenantID:    test.ValidTenantID,
 	}
-	identities, err := client.GetCredentialsObjectUserAssignedIdentities(context.Background(), request)
+	identities, err := client.GetUserAssignedIdentities(context.Background(), request)
 	if err != nil {
 		t.Fatalf("unable to get user assigned msi: %s", err)
 	}


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/ARO-14359

**Issue:**
This PR addresses the concerns [discussed in here](https://github.com/Azure/msi-dataplane/pull/30/files#r1909040805).

**What does this PR do?**
- Export field `Cloud` within `CredentialsObject{}` and `NestedCredentialsObject{}`.
- Update the interfaces to return top level `CredentialsObject{}` to client. Then client should be able the extract the required `NestedCredentialsObject{}` from it.

**Testing:**
- Update and run the unit tests.