### PR TITLE
Add Credentials reload/refresh logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
 	github.com/fsnotify/fsnotify v1.8.0
+	github.com/go-logr/logr v1.4.2
 	github.com/go-playground/validator/v10 v10.22.0
 	go.uber.org/mock v0.4.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
 	github.com/fsnotify/fsnotify v1.8.0
-	github.com/go-logr/logr v1.4.1
 	github.com/go-playground/validator/v10 v10.22.0
 	go.uber.org/mock v0.4.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.1.0
+	github.com/fsnotify/fsnotify v1.8.0
+	github.com/go-logr/logr v1.4.1
 	github.com/go-playground/validator/v10 v10.22.0
 	go.uber.org/mock v0.4.0
 	gopkg.in/dnaeon/go-vcr.v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mx
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
-github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/pkg/dataplane/reloadCredentials.go
+++ b/pkg/dataplane/reloadCredentials.go
@@ -2,6 +2,8 @@ package dataplane
 
 import (
 	"context"
+	"errors"
+	"log"
 	"os"
 	"sync"
 
@@ -10,28 +12,48 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/msi-dataplane/pkg/dataplane/swagger"
 	"github.com/fsnotify/fsnotify"
-	"github.com/go-logr/logr"
+)
+
+var (
+	// Errors returned when reloading credentials
+	errCreateFileWatcher = errors.New("failed to create file watcher")
+	errAddFileToWatcher  = errors.New("failed to add credentialFile to file watcher")
+	errLoadCredentials   = errors.New("failed to load credentials from file")
 )
 
 type reloadingCredential struct {
 	currentValue *azidentity.ClientCertificateCredential
 	cloud        string
 	lock         *sync.RWMutex
-	logger       *logr.Logger
+	logger       *log.Logger
 }
 
 type Option func(*reloadingCredential)
 
-func WithLogger(logger logr.Logger) Option {
+// WithLogger sets a custom logger for the reloadingCredential.
+// This can be useful for debugging or logging purposes.
+func WithLogger(logger *log.Logger) Option {
 	return func(c *reloadingCredential) {
-		c.logger = &logger
+		c.logger = logger
 	}
 }
 
+// NewUserAssignedIdentityCredential creates a new reloadingCredential for a user-assigned identity.
+// ctx is used to manage the lifecycle of the credential, allowing for cancellation and timeouts.
+// cloud specifies the cloud environment.
+// credentialPath is the path to the credential file.
+// opts allows for additional configuration, such as setting a custom logger.
+//
+// The function ensures that a valid token is loaded before returning the credential.
+// It also starts a background process to watch for changes to the credential file and reloads it as necessary.
+// In any case the maximum time that we wait before reload is six hours.
+// Note that while the credential will attempt to keep the token up-to-date, there may be a small delay between
+// when the token expires and when it is reloaded. Users should handle token expiration errors appropriately.
 func NewUserAssignedIdentityCredential(ctx context.Context, cloud string, credentialPath string, opts ...Option) (azcore.TokenCredential, error) {
 	credential := &reloadingCredential{
-		cloud: cloud,
-		lock:  &sync.RWMutex{},
+		cloud:  cloud,
+		lock:   &sync.RWMutex{},
+		logger: log.Default(),
 	}
 
 	for _, opt := range opts {
@@ -47,6 +69,9 @@ func NewUserAssignedIdentityCredential(ctx context.Context, cloud string, creden
 	return credential, nil
 }
 
+// GetToken retrieves the current token from the reloadingCredential.
+// It uses a read lock to ensure that the token is not being modified while it is being read.
+// options specifies additional options for the token request.
 func (r *reloadingCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
@@ -56,19 +81,20 @@ func (r *reloadingCredential) GetToken(ctx context.Context, options policy.Token
 func (r *reloadingCredential) start(ctx context.Context, cloud, credentialFile string) {
 	// set up the file watcher, call load() when we see events or on some timer in case no events are delivered
 	fileWatcher, err := fsnotify.NewWatcher()
-	if err != nil && r.logger != nil {
-		r.logger.Error(err, "failed to create file watcher")
+	if err != nil {
+		r.logger.Printf("%v, %v", errCreateFileWatcher, err)
 	}
 	// we close the file watcher if adding the file to watch fails.
 	// this will also close the new go routine created to watch the file
 	err = fileWatcher.Add(credentialFile)
 	if err != nil {
 		fileWatcher.Close()
-		r.logger.Error(err, "failed to add credentialFile to file watcher")
+		r.logger.Printf("%v, %v", errAddFileToWatcher, err)
 		return
 	}
 
 	go func() {
+		defer fileWatcher.Close()
 		for {
 			select {
 			case event, ok := <-fileWatcher.Events:
@@ -77,20 +103,20 @@ func (r *reloadingCredential) start(ctx context.Context, cloud, credentialFile s
 				}
 				if event.Op.Has(fsnotify.Write) {
 					if err := r.load(cloud, credentialFile); err != nil && r.logger != nil {
-						r.logger.Error(err, "failed to load credentials from file")
+						r.logger.Printf("%v, %v", errLoadCredentials, err)
 					}
 				}
 			case err, ok := <-fileWatcher.Errors:
 				if !ok {
 					return
 				}
-				r.logger.Error(err, "failed to load credentials from file")
+				r.logger.Printf("%v, %v", errLoadCredentials, err)
+			// Keep the function running until the context is done
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
-
-	// Keep the function running until the context is done
-	<-ctx.Done()
 }
 
 func (r *reloadingCredential) load(cloud, credentialFile string) error {
@@ -111,6 +137,9 @@ func (r *reloadingCredential) load(cloud, credentialFile string) error {
 	if err != nil {
 		return err
 	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
 	r.currentValue = newCertValue
 
 	return nil

--- a/pkg/dataplane/reloadCredntials.go
+++ b/pkg/dataplane/reloadCredntials.go
@@ -1,0 +1,117 @@
+package dataplane
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/msi-dataplane/pkg/dataplane/swagger"
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+)
+
+type reloadingCredential struct {
+	currentValue *azidentity.ClientCertificateCredential
+	cloud        string
+	lock         *sync.RWMutex
+	logger       *logr.Logger
+}
+
+type Option func(*reloadingCredential)
+
+func WithLogger(logger logr.Logger) Option {
+	return func(c *reloadingCredential) {
+		c.logger = &logger
+	}
+}
+
+func NewUserAssignedIdentityCredential(ctx context.Context, cloud string, credentialPath string, opts ...Option) (azcore.TokenCredential, error) {
+	credential := &reloadingCredential{
+		cloud: cloud,
+		lock:  &sync.RWMutex{},
+	}
+
+	for _, opt := range opts {
+		opt(credential)
+	}
+
+	// load once to validate everything and ensure we have a useful token before we return
+	if err := credential.load(cloud, credentialPath); err != nil {
+		return nil, err
+	}
+	// start the process of watching - the caller can cancel ctx if they want to stop
+	credential.start(ctx, cloud, credentialPath)
+	return credential, nil
+}
+
+func (r *reloadingCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.currentValue.GetToken(ctx, options)
+}
+
+func (r *reloadingCredential) start(ctx context.Context, cloud, credentialFile string) {
+	// set up the file watcher, call load() when we see events or on some timer in case no events are delivered
+	fileWatcher, err := fsnotify.NewWatcher()
+	if err != nil && r.logger != nil {
+		r.logger.Error(err, "failed to create file watcher")
+	}
+	// we close the file watcher if adding the file to watch fails.
+	// this will also close the new go routine created to watch the file
+	err = fileWatcher.Add(credentialFile)
+	if err != nil {
+		fileWatcher.Close()
+		r.logger.Error(err, "failed to add credentialFile to file watcher")
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-fileWatcher.Events:
+				if !ok {
+					return
+				}
+				if event.Op.Has(fsnotify.Write) {
+					if err := r.load(cloud, credentialFile); err != nil && r.logger != nil {
+						r.logger.Error(err, "failed to load credentials from file")
+					}
+				}
+			case err, ok := <-fileWatcher.Errors:
+				if !ok {
+					return
+				}
+				r.logger.Error(err, "failed to load credentials from file")
+			}
+		}
+	}()
+
+	// Keep the function running until the context is done
+	<-ctx.Done()
+}
+
+func (r *reloadingCredential) load(cloud, credentialFile string) error {
+	// read the file from the filesystem and update the current value we're holding on to if the certificate we read is newer, making sure to not step on the toes of anyone calling GetToken()
+	byteValue, err := os.ReadFile(credentialFile)
+	if err != nil {
+		return err
+	}
+
+	var nestedCreds swagger.NestedCredentialsObject
+	err = nestedCreds.UnmarshalJSON(byteValue)
+	if err != nil {
+		return err
+	}
+
+	var newCertValue *azidentity.ClientCertificateCredential
+	newCertValue, err = getClientCertificateCredential(nestedCreds, cloud)
+	if err != nil {
+		return err
+	}
+	r.currentValue = newCertValue
+
+	return nil
+}


### PR DESCRIPTION
**What does this PR do?**
This PR adds a refresh logic to load the credentials from a file on disk whenever the write or update is detected on the file. The file that need to be watched must be passed by client.
