### PR TITLE
pkg/datplane: expose all Azure client options

### DIFF
--- a/pkg/dataplane/constants.go
+++ b/pkg/dataplane/constants.go
@@ -1,14 +1,5 @@
 package dataplane
 
-type AzureCloud string
-
-const (
-	// Cloud Environments
-	AzurePublicCloud       AzureCloud = "AzurePublicCloud"
-	AzureUSGovernmentCloud AzureCloud = "AzureUSGovernmentCloud"
-	AzureChinaCloud        AzureCloud = "AzureChinaCloud"
-)
-
 const (
 	// MsiIdentityURLHeader is provided by ARM in responses for resource creation
 	// to specify the URL at which clients can get credentials for a managed identity


### PR DESCRIPTION
We were previously being too stringent in asking for clients to present us only a string identifier for the cloud they were in.