### PR TITLE
pkg/dataplane: remove legacy challenge header parsing

### DIFF
--- a/pkg/dataplane/authenticator.go
+++ b/pkg/dataplane/authenticator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/go-logr/logr"
 
 	"github.com/Azure/msi-dataplane/pkg/dataplane/internal/challenge"
 )
@@ -20,7 +19,7 @@ var (
 )
 
 // Authenticating with MSI: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardinginteractionwithmsi .
-func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string, logger *logr.Logger) policy.Policy {
+func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string) policy.Policy {
 	return runtime.NewBearerTokenPolicy(cred, nil, &policy.BearerTokenOptions{
 		AuthorizationHandler: policy.AuthorizationHandler{
 			// Make an unauthenticated request
@@ -30,7 +29,7 @@ func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string, logger
 			// Inspect WWW-Authenticate header returned from challenge
 			OnChallenge: func(req *policy.Request, resp *http.Response, authenticateAndAuthorize func(policy.TokenRequestOptions) error) error {
 				// we expect 'Bearer authorization="https://login.windows-ppe.net/5D929AE3-B37C-46AA-A3C8-C1558902F101"'
-				authParam, err := parseChallengeHeader(logger, resp.Header)
+				authParam, err := parseChallengeHeader(resp.Header)
 				if err != nil {
 					return err
 				}
@@ -56,16 +55,7 @@ func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string, logger
 	})
 }
 
-func parseChallengeHeader(logger *logr.Logger, headers http.Header) (string, error) {
-	val, err := antlrParseChallengeHeader(headers)
-	if err != nil {
-		logger.Error(err, "failed to parse challenge header, falling back to legacy")
-		return legacyParseChallengeHeader(headers)
-	}
-	return val, nil
-}
-
-func antlrParseChallengeHeader(headers http.Header) (string, error) {
+func parseChallengeHeader(headers http.Header) (string, error) {
 	challenges, err := challenge.Parse(headers)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", errInvalidAuthHeader, err)
@@ -83,26 +73,6 @@ func antlrParseChallengeHeader(headers http.Header) (string, error) {
 		return "", fmt.Errorf("%w: %s", errInvalidAuthHeader, "no bearer challenge found")
 	}
 	authParam, provided := bearer.Parameters["authorization"]
-	if !provided {
-		return "", fmt.Errorf("%w: %s", errInvalidAuthHeader, "no authorization parameter in bearer challenge")
-	}
-	return authParam, nil
-}
-
-func legacyParseChallengeHeader(headers http.Header) (string, error) {
-	authHeader := headers.Get("WWW-Authenticate")
-	// Parse the returned challenge
-	parts := strings.Split(authHeader, " ")
-	vals := map[string]string{}
-	for _, part := range parts {
-		subParts := strings.Split(part, "=")
-		if len(subParts) == 2 {
-			stripped := strings.ReplaceAll(subParts[1], "\"", "")
-			stripped = strings.TrimSuffix(stripped, ",")
-			vals[subParts[0]] = stripped
-		}
-	}
-	authParam, provided := vals["authorization"]
 	if !provided {
 		return "", fmt.Errorf("%w: %s", errInvalidAuthHeader, "no authorization parameter in bearer challenge")
 	}

--- a/pkg/dataplane/authenticator_test.go
+++ b/pkg/dataplane/authenticator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/go-logr/logr/testr"
 	. "github.com/onsi/gomega"
 )
 
@@ -83,10 +82,9 @@ func TestNewAuthenticatorPolicy(t *testing.T) {
 			t.Parallel()
 			g := NewWithT(t)
 
-			log := testr.New(t)
 			pipeline := runtime.NewPipeline("", "", runtime.PipelineOptions{
 				PerCall: []policy.Policy{
-					newAuthenticatorPolicy(&FakeCredential{}, "https://identity_url.com/", &log),
+					newAuthenticatorPolicy(&FakeCredential{}, "https://identity_url.com/"),
 				},
 			}, &policy.ClientOptions{
 				Transport: tt.fakeTransport,

--- a/pkg/dataplane/client_factory.go
+++ b/pkg/dataplane/client_factory.go
@@ -102,7 +102,7 @@ func (c *clientFactory) NewClient(identityURL string) (Client, error) {
 				req.Raw().URL.RawQuery = query.Encode()
 				return req.Next()
 			}),
-			newAuthenticatorPolicy(c.cred, c.audience, c.cfOpts.logger),
+			newAuthenticatorPolicy(c.cred, c.audience),
 		},
 	}, c.clientOpts)
 	if err != nil {


### PR DESCRIPTION
The ANTLR version works as expected, we no longer need the fallback.