### PR TITLE
pkg/dataplane: add UAMSI helper for KeyVault, expose names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Package `msi-dataplane` is a module for Azure resource providers to interact with MSI's dataplane.
 
+## Usage
+
+Please see the [sample program](./pkg/dataplane/internal/sample/client.go) for an example of how to use this client.
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/pkg/dataplane/internal/sample/client.go
+++ b/pkg/dataplane/internal/sample/client.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+
+	"github.com/Azure/msi-dataplane/pkg/dataplane"
+)
+
+func main() {
+	azureCredential, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		log.Fatalf("failed to initialize azure credentials: %v", err)
+	}
+
+	// create a client for the MSI dataplane
+	factory := dataplane.NewClientFactory(azureCredential, "audience", nil)
+
+	identityURL := "" // value of the x-ms-identity-url header from ARM
+	msiClient, err := factory.NewClient(identityURL)
+	if err != nil {
+		log.Fatalf("error creating msi dataplane client: %v", err)
+	}
+
+	// get the credential for some identities
+	credential, err := msiClient.GetUserAssignedIdentitiesCredentials(context.Background(), dataplane.UserAssignedIdentitiesRequest{
+		IdentityIDs: []string{
+			"someIdentity",
+			"someOtherIdentity",
+		},
+	})
+	if err != nil {
+		log.Fatalf("error retrieving credential: %v", err)
+	}
+
+	// create a client for KeyVault
+	keyVaultUrl := "" // from your configuration
+	secretsClient, err := azsecrets.NewClient(keyVaultUrl, azureCredential, nil)
+	if err != nil {
+		log.Fatalf("error creating secrets client: %v", err)
+	}
+
+	// either store as a single msi in KeyVault
+	identifier := "" // something meaningful to you
+	name, params, err := dataplane.FormatManagedIdentityCredentialsForStorage(identifier, *credential)
+	if err != nil {
+		log.Fatalf("error formatting managed identity credentials: %v", err)
+	}
+	if _, err := secretsClient.SetSecret(context.Background(), name, params, nil); err != nil {
+		log.Fatalf("error uploading managed identity credentials to key vault: %v", err)
+	}
+
+	// or store individual uamsi values
+	for _, identity := range credential.ExplicitIdentities {
+		name, params, err := dataplane.FormatUserAssignedIdentityCredentialsForStorage(identifier, identity)
+		if err != nil {
+			log.Fatalf("error formatting user-assigned managed identity credentials: %v", err)
+		}
+		if _, err := secretsClient.SetSecret(context.Background(), name, params, nil); err != nil {
+			log.Fatalf("error uploading user-assigned managed identity credentials to key vault: %v", err)
+		}
+	}
+}

--- a/pkg/dataplane/keyvault_test.go
+++ b/pkg/dataplane/keyvault_test.go
@@ -147,3 +147,82 @@ func TestFormatManagedIdentityCredentialsForStorage(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatUserAssignedIdentityCredentialsForStorage(t *testing.T) {
+	var notAfter, notBefore, renewAfter, cannotRenewAfter time.Time
+	for raw, into := range map[string]*time.Time{
+		"2006-01-02T15:04:05Z": &notAfter,
+		"2001-01-02T15:04:05Z": &notBefore,
+		"2003-01-02T15:04:05Z": &renewAfter,
+		"2023-01-02T15:04:05Z": &cannotRenewAfter,
+	} {
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			t.Fatalf("failed to parse %q: %v", raw, err)
+		}
+		*into = parsed
+	}
+
+	for _, testCase := range []struct {
+		name             string
+		identifier       string
+		credentials      UserAssignedIdentityCredentials
+		keyVaultItemName string
+		parameters       azsecrets.SetSecretParameters
+		err              bool
+	}{
+		{
+			name:       "valid uamsi credentials",
+			identifier: "test",
+			credentials: UserAssignedIdentityCredentials{
+				ClientSecretURL:  ptrTo("whatever"),
+				CannotRenewAfter: ptrTo(cannotRenewAfter.Format(time.RFC3339)),
+				NotAfter:         ptrTo(notAfter.Format(time.RFC3339)),
+				NotBefore:        ptrTo(notBefore.Format(time.RFC3339)),
+				RenewAfter:       ptrTo(renewAfter.Format(time.RFC3339)),
+			},
+			keyVaultItemName: "uamsi-test",
+			parameters: azsecrets.SetSecretParameters{
+				Value: ptrTo(`{"cannot_renew_after":"2023-01-02T15:04:05Z","client_secret_url":"whatever","not_after":"2006-01-02T15:04:05Z","not_before":"2001-01-02T15:04:05Z","renew_after":"2003-01-02T15:04:05Z"}`),
+				SecretAttributes: &azsecrets.SecretAttributes{
+					Enabled:   ptrTo(true),
+					Expires:   ptrTo(notAfter),
+					NotBefore: ptrTo(notBefore),
+				},
+				Tags: map[string]*string{
+					"renew_after":        ptrTo(renewAfter.Format(time.RFC3339)),
+					"cannot_renew_after": ptrTo(cannotRenewAfter.Format(time.RFC3339)),
+				},
+			},
+		},
+		{
+			name:       "invalid uamsi credentials",
+			identifier: "test",
+			credentials: UserAssignedIdentityCredentials{
+				ClientSecretURL:  ptrTo("whatever"),
+				CannotRenewAfter: ptrTo(cannotRenewAfter.Format(time.RFC3339)),
+				NotAfter:         ptrTo(notAfter.Format(time.RFC3339)),
+				NotBefore:        ptrTo("oops"),
+				RenewAfter:       ptrTo(renewAfter.Format(time.RFC3339)),
+			},
+			err: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			name, parameters, err := FormatUserAssignedIdentityCredentialsForStorage(testCase.identifier, testCase.credentials)
+			if err == nil && testCase.err {
+				t.Fatalf("%s: expected error, got none", testCase.name)
+			}
+			if err != nil && !testCase.err {
+				t.Fatalf("%s: expected no error, got %v", testCase.name, err)
+			}
+
+			if name != testCase.keyVaultItemName {
+				t.Errorf("%s: expected name %q, got %q", testCase.name, testCase.keyVaultItemName, name)
+			}
+			if diff := cmp.Diff(parameters, testCase.parameters); diff != "" {
+				t.Errorf("%s: parameters (-want, +got) = %v", testCase.name, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Users need to be able to determine the canonical name for a KeyVault item before they have a handle to a full credential, as they use the name for getting the item from KeyVault at startup.

Also, add support for storing UAMSI credentials in KeyVault.