### PR TITLE
pkg/dataplane: improve errors in reloading credentials

### DIFF
--- a/pkg/dataplane/reloadCredentials.go
+++ b/pkg/dataplane/reloadCredentials.go
@@ -112,7 +112,11 @@ func (r *reloadingCredential) start(ctx context.Context, credentialFile string) 
 	}
 
 	go func() {
-		defer fileWatcher.Close()
+		defer func() {
+			if err := fileWatcher.Close(); err != nil {
+				r.logger.Error(err, "failed to close file watcher")
+			}
+		}()
 		defer r.ticker.Stop()
 		for {
 			select {


### PR DESCRIPTION
pkg/dataplane: surface errors starting watcher

We have the ability to surface these errors to the caller before
starting the watcher, so we should choose to do that. An early return
also guards against undefined behavior where the watcher may not have
been correctl instantiated in the past.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

pkg/dataplane: expose errors in deferred call

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

pkg/dataplane: clarify error messages

Error messages that are precise and trace-able help users understand
what went wrong and why.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

