### PR TITLE
pin autorest version and update runner os

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Version of autorest to use for code generation
+AUTOREST_VERSION := 3.7.1
+AUTOREST_CORE_VERSION := 3.10.3
+
 include ./.bingo/Variables.mk
 
 # ADO does not expose an unauthenticated API for fetching one file, and the git server
@@ -10,7 +14,10 @@ pkg/dataplane/internal/msi-credentials-data-plane.openapi.v2.json:
 	rm -rf ManagedIdentity-MIRP
 
 _autorest-docker-image:
-	cd pkg/dataplane/internal && docker build -t azuresdk/autorest -f autorest.Dockerfile .
+	cd pkg/dataplane/internal && docker build -t azuresdk/autorest \
+		--build-arg AUTOREST_VERSION=$(AUTOREST_VERSION) \
+		--build-arg AUTOREST_CORE_VERSION=$(AUTOREST_CORE_VERSION) \
+		-f autorest.Dockerfile .
 	docker inspect azuresdk/autorest > $@
 
 pkg/dataplane/internal/client/models.go: _autorest-docker-image

--- a/pkg/dataplane/internal/autorest.Dockerfile
+++ b/pkg/dataplane/internal/autorest.Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts
 
-RUN npm install -g autorest
+ARG AUTOREST_VERSION
+ARG AUTOREST_CORE_VERSION
+RUN npm install -g @autorest/core@${AUTOREST_CORE_VERSION} autorest@${AUTOREST_VERSION}
 
 ENTRYPOINT ["autorest"]


### PR DESCRIPTION
pin autorest and core versions so that generated codes don't vary over time

also fixes #53 