### PR TITLE
fix: propagate InsecureAllowCredentialWithHTTP from client options

### DIFF
--- a/pkg/dataplane/authenticator.go
+++ b/pkg/dataplane/authenticator.go
@@ -19,7 +19,7 @@ var (
 )
 
 // Authenticating with MSI: https://eng.ms/docs/products/arm/rbac/managed_identities/msionboardinginteractionwithmsi .
-func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string) policy.Policy {
+func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string, allowHTTP bool) policy.Policy {
 	return runtime.NewBearerTokenPolicy(cred, nil, &policy.BearerTokenOptions{
 		AuthorizationHandler: policy.AuthorizationHandler{
 			// Make an unauthenticated request
@@ -52,6 +52,7 @@ func newAuthenticatorPolicy(cred azcore.TokenCredential, audience string) policy
 				})
 			},
 		},
+		InsecureAllowCredentialWithHTTP: allowHTTP,
 	})
 }
 

--- a/pkg/dataplane/authenticator_test.go
+++ b/pkg/dataplane/authenticator_test.go
@@ -84,7 +84,7 @@ func TestNewAuthenticatorPolicy(t *testing.T) {
 
 			pipeline := runtime.NewPipeline("", "", runtime.PipelineOptions{
 				PerCall: []policy.Policy{
-					newAuthenticatorPolicy(&FakeCredential{}, "https://identity_url.com/"),
+					newAuthenticatorPolicy(&FakeCredential{}, "https://identity_url.com/", false),
 				},
 			}, &policy.ClientOptions{
 				Transport: tt.fakeTransport,
@@ -95,6 +95,80 @@ func TestNewAuthenticatorPolicy(t *testing.T) {
 
 			resp, err := pipeline.Do(req)
 			tt.validateRes(g, tt.fakeTransport, resp, err)
+		})
+	}
+}
+
+func Test_AuthenticatorPolicy_AllowHTTP(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		allowHTTP   bool
+		targetURL   string
+		expectError bool
+	}{
+		{
+			name:        "HTTP disallowed with https target url",
+			allowHTTP:   false,
+			targetURL:   "https://localhost/",
+			expectError: false,
+		},
+		{
+			name:        "HTTP disallowed with http target url",
+			allowHTTP:   false,
+			targetURL:   "http://localhost/",
+			expectError: true,
+		},
+		{
+			name:        "HTTP allowed with https target url",
+			allowHTTP:   true,
+			targetURL:   "https://localhost/",
+			expectError: false,
+		},
+		{
+			name:        "HTTP allowed with http target url",
+			allowHTTP:   true,
+			targetURL:   "http://localhost/",
+			expectError: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			pipeline := runtime.NewPipeline("", "", runtime.PipelineOptions{
+				PerCall: []policy.Policy{
+					newAuthenticatorPolicy(&FakeCredential{}, "https://identity_url.com/", tt.allowHTTP),
+				},
+			}, &policy.ClientOptions{
+				Transport: &fakeTransport{
+					resps: []*http.Response{
+						{
+							StatusCode: http.StatusUnauthorized,
+							Header: http.Header{
+								"Www-Authenticate": []string{`Bearer authorization="https://login.windows-ppe.net/5D929AE3-B37C-46AA-A3C8-C1558902F101"`},
+							},
+							Body: http.NoBody,
+						},
+						{
+							StatusCode: http.StatusOK,
+							Body:       http.NoBody,
+						},
+					},
+				},
+			})
+
+			req, err := runtime.NewRequest(context.Background(), http.MethodGet, tt.targetURL)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			resp, err := pipeline.Do(req)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			}
 		})
 	}
 }

--- a/pkg/dataplane/client_factory.go
+++ b/pkg/dataplane/client_factory.go
@@ -102,7 +102,7 @@ func (c *clientFactory) NewClient(identityURL string) (Client, error) {
 				req.Raw().URL.RawQuery = query.Encode()
 				return req.Next()
 			}),
-			newAuthenticatorPolicy(c.cred, c.audience),
+			newAuthenticatorPolicy(c.cred, c.audience, c.clientOpts.InsecureAllowCredentialWithHTTP),
 		},
 	}, c.clientOpts)
 	if err != nil {


### PR DESCRIPTION
The `policy.BearerTokenOptions` accepts settings `InsecureAllowCredentialWithHTTP` for disabling HTTPs check when sending the request. This option is helpful in test environment where HTTP endpoint will be used.

This change updates the `newAuthenticatorPolicy` function to propagate the settings from `clientOpts.InsecureAllowCredentialWithHTTP` to the `BearerTokenOptions`.